### PR TITLE
ピアノロール・マスター波形・再生バグ修正・UI改善

### DIFF
--- a/index.html
+++ b/index.html
@@ -1074,8 +1074,6 @@
     // ピアノロール描画
     // ============================================================
 
-    let pianoRollAnimId = null;
-
     function drawPianoRoll() {
       const canvas = document.getElementById('piano-roll-canvas');
       const ctx = canvas.getContext('2d');
@@ -1133,41 +1131,6 @@
       }
     }
 
-    // ピアノロール再生ヘッド
-    function startPianoRollPlayhead() {
-      cancelAnimationFrame(pianoRollAnimId);
-      const canvas = document.getElementById('piano-roll-canvas');
-      const ctx = canvas.getContext('2d');
-      const dpr = window.devicePixelRatio || 1;
-
-      function frame() {
-        if (!isPlaying) return;
-        const elapsed = (performance.now() - playbackStartReal) / 1000 + playbackStartOffset;
-        const dur = currentTotalDuration || 1;
-
-        // 再描画
-        drawPianoRoll();
-        const W = canvas.clientWidth;
-        const H = canvas.clientHeight;
-        const PADDING_LEFT = 0;
-        const plotW = W - PADDING_LEFT;
-
-        // ヘッドライン
-        const x = PADDING_LEFT + (elapsed / dur) * plotW;
-        ctx.save();
-        ctx.strokeStyle = '#ff4444';
-        ctx.lineWidth = 2;
-        ctx.beginPath();
-        ctx.moveTo(x, 0);
-        ctx.lineTo(x, H - 20);
-        ctx.stroke();
-        ctx.restore();
-
-        pianoRollAnimId = requestAnimationFrame(frame);
-      }
-      pianoRollAnimId = requestAnimationFrame(frame);
-    }
-
     // ピアノロールクリックでシーク
     document.getElementById('piano-roll-canvas').addEventListener('click', (e) => {
       if (!currentNotes.length) return;
@@ -1206,7 +1169,7 @@
         ctx.lineWidth = 2;
         ctx.beginPath();
         ctx.moveTo(x, 0);
-        ctx.lineTo(x, H - 20);
+        ctx.lineTo(x, H);
         ctx.stroke();
         ctx.restore();
       }


### PR DESCRIPTION
## What
- ピアノロール（Canvas描画、チャンネル色分け、ミュート連動、クリックシーク、再生ヘッド）
- マスター合成波形（ビジュアライザー最上部、全チャンネルミックス）
- 再生停止タイマーバグ修正（2回目再生が早く止まる問題）
- totalDuration計算修正（全ノートの最大終了時刻で計算）
- 波形ビジュアライザー4列固定レイアウト
- ピアノロールをカードモジュール化（ビジュアライザーと統一デザイン）
- シークバー削除（ピアノロールクリックで代替）

## Why
再生品質とビジュアル表現の強化。MIDIの全体像を直感的に把握できるようにする。

## Risk
Low — 表示系の追加と既存バグ修正のみ