### PR TITLE
ci: add GitHub Actions lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,19 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run lint


### PR DESCRIPTION
## What
GitHub ActionsでBiome lintをCIとして実行するワークフローを追加。

## Why
PRおよびmain pushで自動的にlintチェックを行い、コード品質を維持するため。紗夜のPR #5レビューでの提案を反映。

## Risk
低。CI設定追加のみ、既存コードへの変更なし。