### PR TITLE
ci: add E2E test workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,20 @@
+name: E2E Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npm test


### PR DESCRIPTION
## What
GitHub ActionsでPlaywright E2Eテストを実行するワークフローを追加。

## Why
PRおよびmain pushで自動的にE2Eテストを実行し、UIリグレッションを検知するため。

## 構成
- `e2e.yml`: lint.ymlと同じトリガー（push/PR on main）
- `npx playwright install --with-deps chromium` でCI環境にブラウザ+依存ライブラリをインストール
- `npm test` で6テスト実行

## Risk
低。CI設定追加のみ。