### PR TITLE
feat: real-time wave type switching during playback

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -46,6 +46,21 @@ fileInput.addEventListener('change', () => {
   if (fileInput.files.length > 0) loadFile(fileInput.files[0]);
 });
 
+// 波形リアルタイム切替
+const waveType = document.getElementById('wave-type');
+waveType.addEventListener('change', () => {
+  const newType = waveType.value;
+  if (typeof scheduledNodes !== 'undefined') {
+    for (const osc of scheduledNodes) {
+      try {
+        osc.type = newType;
+      } catch (_) {
+        /* already stopped */
+      }
+    }
+  }
+});
+
 // ボリュームコントロール
 masterVolume.addEventListener('input', () => {
   const val = masterVolume.value;


### PR DESCRIPTION
## What
再生中に波形タイプ（Triangle/Sine/Square/Sawtooth）をリアルタイムで切り替え可能に。

## Why
再生を止めずに音色を試せるようにするため。

## 仕組み
波形セレクターの`change`イベントで、`scheduledNodes`内の全オシレーターの`.type`を即座に更新。既に停止したオシレーターはtry-catchで無視。

## Risk
低。既存の再生ロジックに変更なし、イベントリスナー追加のみ。