### PR TITLE
feat: チャンネル別エフェクター音声処理接続

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -308,6 +308,21 @@ document.addEventListener('change', (e) => {
     const slider = e.target.closest('.fx-mod-row').querySelector('.ch-fx-slider');
     slider.disabled = !e.target.checked;
     chFx[fx].enabled = e.target.checked;
+
+    const state = channelStates[ch];
+    if (state?.fxNodes) {
+      if (fx === 'distortion') {
+        state.fxNodes.distDry.gain.value = e.target.checked ? 0 : 1;
+        state.fxNodes.distWet.gain.value = e.target.checked ? 1 : 0;
+        if (e.target.checked) {
+          updateDistortionCurve(state.fxNodes.distortion, chFx.distortion.amount);
+        }
+      } else if (fx === 'delay') {
+        state.fxNodes.delayWet.gain.value = e.target.checked ? 0.5 : 0;
+      } else if (fx === 'reverb') {
+        state.fxNodes.reverbWet.gain.value = e.target.checked ? chFx.reverb.mix / 100 : 0;
+      }
+    }
   }
 });
 
@@ -319,9 +334,24 @@ document.addEventListener('input', (e) => {
     const chFx = getChannelFx(ch);
     const valDisplay = e.target.closest('.fx-mod-row').querySelector('.ch-fx-val');
     valDisplay.textContent = e.target.value;
-    if (fx === 'distortion') chFx.distortion.amount = Number(e.target.value);
-    else if (fx === 'delay') chFx.delay.time = Number(e.target.value);
-    else if (fx === 'reverb') chFx.reverb.mix = Number(e.target.value);
+
+    const state = channelStates[ch];
+    if (fx === 'distortion') {
+      chFx.distortion.amount = Number(e.target.value);
+      if (state?.fxNodes && chFx.distortion.enabled) {
+        updateDistortionCurve(state.fxNodes.distortion, chFx.distortion.amount);
+      }
+    } else if (fx === 'delay') {
+      chFx.delay.time = Number(e.target.value);
+      if (state?.fxNodes) {
+        state.fxNodes.delay.delayTime.value = Number(e.target.value) / 1000;
+      }
+    } else if (fx === 'reverb') {
+      chFx.reverb.mix = Number(e.target.value);
+      if (state?.fxNodes && chFx.reverb.enabled) {
+        state.fxNodes.reverbWet.gain.value = Number(e.target.value) / 100;
+      }
+    }
   }
 });
 

--- a/js/audio-engine.js
+++ b/js/audio-engine.js
@@ -140,18 +140,88 @@ async function playNotes(notes, bpm, seekOffset = 0) {
   // チャンネルごとのオーディオノード作成
   for (const ch of currentChannels) {
     const state = channelStates[ch];
+    const chFx = getChannelFx(ch);
 
     const gainNode = audioCtx.createGain();
     gainNode.gain.value = 1;
 
+    // --- チャンネル別FXノード (dry/wet方式) ---
+
+    // Distortion
+    const chDistDry = audioCtx.createGain();
+    const chDistWet = audioCtx.createGain();
+    const chDistNode = audioCtx.createWaveShaper();
+    chDistNode.oversample = '4x';
+    const chDistMerge = audioCtx.createGain();
+    chDistDry.gain.value = 1;
+    chDistWet.gain.value = 0;
+    if (chFx.distortion.enabled) {
+      chDistDry.gain.value = 0;
+      chDistWet.gain.value = 1;
+      updateDistortionCurve(chDistNode, chFx.distortion.amount);
+    }
+    gainNode.connect(chDistDry);
+    gainNode.connect(chDistNode);
+    chDistNode.connect(chDistWet);
+    chDistDry.connect(chDistMerge);
+    chDistWet.connect(chDistMerge);
+
+    // Delay
+    const chDelayDry = audioCtx.createGain();
+    const chDelayWet = audioCtx.createGain();
+    const chDelayNode = audioCtx.createDelay(1.0);
+    const chDelayFeedback = audioCtx.createGain();
+    const chDelayMerge = audioCtx.createGain();
+    chDelayNode.delayTime.value = chFx.delay.time / 1000;
+    chDelayFeedback.gain.value = 0.3;
+    chDelayDry.gain.value = 1;
+    chDelayWet.gain.value = 0;
+    if (chFx.delay.enabled) {
+      chDelayWet.gain.value = 0.5;
+    }
+    chDelayNode.connect(chDelayFeedback);
+    chDelayFeedback.connect(chDelayNode);
+    chDelayNode.connect(chDelayWet);
+    chDistMerge.connect(chDelayDry);
+    chDistMerge.connect(chDelayNode);
+    chDelayDry.connect(chDelayMerge);
+    chDelayWet.connect(chDelayMerge);
+
+    // Reverb
+    const chReverbDry = audioCtx.createGain();
+    const chReverbWet = audioCtx.createGain();
+    const chConvolver = audioCtx.createConvolver();
+    chConvolver.buffer = createReverbIR(audioCtx, 2, 2);
+    const chReverbMerge = audioCtx.createGain();
+    chReverbDry.gain.value = 1;
+    chReverbWet.gain.value = 0;
+    if (chFx.reverb.enabled) {
+      chReverbWet.gain.value = chFx.reverb.mix / 100;
+    }
+    chDelayMerge.connect(chReverbDry);
+    chDelayMerge.connect(chConvolver);
+    chConvolver.connect(chReverbWet);
+    chReverbDry.connect(chReverbMerge);
+    chReverbWet.connect(chReverbMerge);
+
+    // Analyser → Master
     const analyser = audioCtx.createAnalyser();
     analyser.fftSize = 2048;
-
-    gainNode.connect(analyser);
+    chReverbMerge.connect(analyser);
     analyser.connect(masterGain);
 
     state.gainNode = gainNode;
     state.analyser = analyser;
+    state.fxNodes = {
+      distortion: chDistNode,
+      distDry: chDistDry,
+      distWet: chDistWet,
+      delay: chDelayNode,
+      delayWet: chDelayWet,
+      delayFeedback: chDelayFeedback,
+      convolver: chConvolver,
+      reverbWet: chReverbWet,
+    };
 
     // Canvasサイズ設定
     const canvas = document.getElementById(`waveform-${ch}`);


### PR DESCRIPTION
## What
- チャンネルごとにDistortion(WaveShaper)/Delay/Reverb(Convolver)のオーディオノードを生成
- dry/wet方式でバイパス制御（OFF: dry=1,wet=0 / ON: wet有効化）
- UIのトグル・スライダーからリアルタイムでノードパラメータを更新
- チェーン: ChGain → Dist(dry/wet) → Delay(dry/wet) → Reverb(dry/wet) → Analyser → MasterGain
- グローバルFXチェーンはそのまま維持

## Why
- PR #19 で作成したチャンネル別FXモジュールUIに音声処理を接続
- チャンネルごとに異なるエフェクト設定が可能に

## Risk
- Medium — チャンネル別にFXノードを大量生成するためCPU負荷が増加する可能性
- dry/wet方式のため切替時のノイズリスクは低い