### PR TITLE
feat: スペクトラム表示 + グローバルフィルター

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,6 +105,35 @@
       </div>
 
       <div class="panel-section">
+        <h3><i data-lucide="activity"></i> スペクトラム</h3>
+        <canvas id="spectrum-canvas" height="100" style="width:100%; border-radius:4px; background:var(--bg-canvas); display:block; cursor:crosshair;"></canvas>
+        <div id="filter-controls" style="margin-top:6px;">
+          <div class="fx-row">
+            <label class="fx-toggle">
+              <input type="checkbox" id="filter-enabled">
+              <span>Filter</span>
+            </label>
+            <select id="filter-type" style="font-size:0.7rem;" disabled>
+              <option value="lowpass">Lowpass</option>
+              <option value="highpass">Highpass</option>
+              <option value="bandpass">Bandpass</option>
+              <option value="notch">Notch</option>
+            </select>
+          </div>
+          <div class="fx-row">
+            <span class="fx-val" style="min-width:28px">Freq</span>
+            <input type="range" id="filter-freq" class="fx-slider" min="20" max="20000" value="1000" disabled>
+            <span class="fx-val" id="filter-freq-val">1000</span>
+          </div>
+          <div class="fx-row">
+            <span class="fx-val" style="min-width:28px">Q</span>
+            <input type="range" id="filter-q" class="fx-slider" min="0.1" max="20" value="1" step="0.1" disabled>
+            <span class="fx-val" id="filter-q-val">1.0</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="panel-section">
         <h3><i data-lucide="zap"></i> エフェクト</h3>
         <div id="fx-controls">
           <div class="fx-row">

--- a/js/app.js
+++ b/js/app.js
@@ -355,6 +355,124 @@ document.addEventListener('input', (e) => {
   }
 });
 
+// スペクトラム描画
+const spectrumCanvas = document.getElementById('spectrum-canvas');
+const specCtx = spectrumCanvas.getContext('2d');
+let spectrumTimer = null;
+
+function startSpectrumDraw() {
+  if (spectrumTimer) return;
+  spectrumTimer = setInterval(() => {
+    const analyser = window._spectrumAnalyser;
+    if (!analyser) return;
+
+    spectrumCanvas.width = spectrumCanvas.offsetWidth;
+    const w = spectrumCanvas.width;
+    const h = spectrumCanvas.height;
+    const bufLen = analyser.frequencyBinCount;
+    const data = new Uint8Array(bufLen);
+    analyser.getByteFrequencyData(data);
+
+    specCtx.fillStyle = getThemeColor('--bg-canvas', '#140f1a');
+    specCtx.fillRect(0, 0, w, h);
+
+    // スペクトラムバー (対数スケール)
+    const nyquist = 24000;
+    const minFreq = 20;
+    const maxFreq = 20000;
+
+    specCtx.fillStyle = getThemeColor('--accent-purple', '#b39ddb');
+    specCtx.globalAlpha = 0.6;
+    for (let i = 0; i < w; i++) {
+      const freq = minFreq * (maxFreq / minFreq) ** (i / w);
+      const bin = Math.round((freq / nyquist) * bufLen);
+      if (bin >= bufLen) break;
+      const val = data[bin] / 255;
+      const barH = val * h;
+      specCtx.fillRect(i, h - barH, 1, barH);
+    }
+    specCtx.globalAlpha = 1;
+
+    // フィルターカットオフ線
+    if (window._globalFilterEnabled) {
+      const filterFreq = window._globalFilter?.frequency.value || 1000;
+      const x = w * (Math.log(filterFreq / minFreq) / Math.log(maxFreq / minFreq));
+      specCtx.strokeStyle = getThemeColor('--accent-green', '#81c784');
+      specCtx.lineWidth = 2;
+      specCtx.setLineDash([4, 4]);
+      specCtx.beginPath();
+      specCtx.moveTo(x, 0);
+      specCtx.lineTo(x, h);
+      specCtx.stroke();
+      specCtx.setLineDash([]);
+
+      // 周波数ラベル
+      specCtx.fillStyle = getThemeColor('--accent-green', '#81c784');
+      specCtx.font = '10px monospace';
+      specCtx.fillText(`${Math.round(filterFreq)}Hz`, x + 4, 12);
+    }
+  }, 50);
+}
+
+function stopSpectrumDraw() {
+  if (spectrumTimer) {
+    clearInterval(spectrumTimer);
+    spectrumTimer = null;
+  }
+}
+
+// フィルターコントロール
+const filterEnabled = document.getElementById('filter-enabled');
+const filterType = document.getElementById('filter-type');
+const filterFreq = document.getElementById('filter-freq');
+const filterQ = document.getElementById('filter-q');
+const filterFreqVal = document.getElementById('filter-freq-val');
+const filterQVal = document.getElementById('filter-q-val');
+
+filterEnabled.addEventListener('change', () => {
+  filterType.disabled = !filterEnabled.checked;
+  filterFreq.disabled = !filterEnabled.checked;
+  filterQ.disabled = !filterEnabled.checked;
+  window._globalFilterEnabled = filterEnabled.checked;
+  if (window._globalFilter) {
+    if (filterEnabled.checked) {
+      window._globalFilter.type = filterType.value;
+      window._globalFilter.frequency.value = Number(filterFreq.value);
+      window._globalFilter.Q.value = Number(filterQ.value);
+    } else {
+      window._globalFilter.type = 'lowpass';
+      window._globalFilter.frequency.value = 20000;
+      window._globalFilter.Q.value = 0.1;
+    }
+  }
+});
+
+filterType.addEventListener('change', () => {
+  if (window._globalFilter) window._globalFilter.type = filterType.value;
+});
+
+filterFreq.addEventListener('input', () => {
+  filterFreqVal.textContent = filterFreq.value;
+  if (window._globalFilter) window._globalFilter.frequency.value = Number(filterFreq.value);
+});
+
+filterQ.addEventListener('input', () => {
+  filterQVal.textContent = Number(filterQ.value).toFixed(1);
+  if (window._globalFilter) window._globalFilter.Q.value = Number(filterQ.value);
+});
+
+// スペクトラムcanvasクリックでフィルター周波数設定
+spectrumCanvas.addEventListener('click', (e) => {
+  if (!filterEnabled.checked) return;
+  const rect = spectrumCanvas.getBoundingClientRect();
+  const x = e.clientX - rect.left;
+  const ratio = x / spectrumCanvas.width;
+  const freq = Math.round(20 * (20000 / 20) ** ratio);
+  filterFreq.value = freq;
+  filterFreqVal.textContent = freq;
+  if (window._globalFilter) window._globalFilter.frequency.value = freq;
+});
+
 // Lucide アイコン初期化
 if (typeof lucide !== 'undefined') {
   lucide.createIcons();

--- a/js/audio-engine.js
+++ b/js/audio-engine.js
@@ -55,6 +55,20 @@ async function playNotes(notes, bpm, seekOffset = 0) {
   masterGain.gain.value = waveVol * mVol;
   window._masterGain = masterGain;
 
+  // スペクトラム表示用Analyser (masterGain前に配置)
+  const spectrumAnalyser = audioCtx.createAnalyser();
+  spectrumAnalyser.fftSize = 4096;
+  spectrumAnalyser.smoothingTimeConstant = 0.8;
+  window._spectrumAnalyser = spectrumAnalyser;
+
+  // グローバルフィルター (masterGainとEQの間に挿入)
+  const globalFilter = audioCtx.createBiquadFilter();
+  globalFilter.type = document.getElementById('filter-type').value;
+  globalFilter.frequency.value = Number(document.getElementById('filter-freq').value);
+  globalFilter.Q.value = Number(document.getElementById('filter-q').value);
+  window._globalFilter = globalFilter;
+  window._globalFilterEnabled = document.getElementById('filter-enabled').checked;
+
   // マスター合成波用AnalyserNode
   // EQ フィルターチェーン
   const eqBands = document.querySelectorAll('.eq-band');
@@ -70,7 +84,17 @@ async function playNotes(notes, bpm, seekOffset = 0) {
   });
 
   // masterGain → EQ chain → analyser → destination
-  let prevNode = masterGain;
+  // masterGain → spectrumAnalyser (表示用、音声経路外)
+  // masterGain → globalFilter → EQ (フィルターは常に接続、OFF時はallpass的に動作)
+  masterGain.connect(spectrumAnalyser);
+  if (!window._globalFilterEnabled) {
+    // OFF時: 高周波数のlowpassで実質素通し
+    globalFilter.type = 'lowpass';
+    globalFilter.frequency.value = 20000;
+    globalFilter.Q.value = 0.1;
+  }
+  masterGain.connect(globalFilter);
+  let prevNode = globalFilter;
   for (const filter of eqFilters) {
     prevNode.connect(filter);
     prevNode = filter;
@@ -384,6 +408,7 @@ async function playNotes(notes, bpm, seekOffset = 0) {
   btnPlay.innerHTML = '<i data-lucide="pause"></i> 一時停止';
   lucide.createIcons({ nameAttr: 'data-lucide', node: btnPlay });
   btnPlay.disabled = false;
+  if (typeof startSpectrumDraw === 'function') startSpectrumDraw();
   btnStop.disabled = false;
 
   // シークバー表示・設定
@@ -459,6 +484,7 @@ function resumePlayback() {
 }
 
 function stopPlayback() {
+  if (typeof stopSpectrumDraw === 'function') stopSpectrumDraw();
   isPaused = false;
   pauseDuration = 0;
   pauseStartTime = 0;


### PR DESCRIPTION
## What
- リアルタイム周波数スペクトラム表示（AnalyserNode, 対数スケール）
- グローバルフィルター: Lowpass / Highpass / Bandpass / Notch
- Freq(20-20kHz) / Q(0.1-20) スライダーでリアルタイム調整
- Canvas上クリックでカットオフ周波数を直接設定
- カットオフ位置を緑点線で可視化
- OFF時はlowpass 20kHz/Q=0.1で素通し（常時接続方式）

## Why
- 周波数帯域の可視化で音の構成を直感的に把握
- フィルターで不要な帯域をカットする音作り機能

## Risk
- Low — フィルターは常時接続だがOFF時は素通し設定。既存音声チェーンへの影響なし