### PR TITLE
feat: per-channel wave volume

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -39,7 +39,7 @@ function applyCurrentWaveVolume() {
   applyChannelWaveVolumes();
 }
 
-// 各チャンネルの gainNode に波形別音量を適用
+// 各チャンネルの waveGain に波形別音量を適用
 function applyChannelWaveVolumes() {
   if (typeof channelStates === 'undefined') return;
   for (const [ch, state] of Object.entries(channelStates)) {
@@ -47,8 +47,8 @@ function applyChannelWaveVolumes() {
     const chFx = getChannelFx(Number(ch));
     const waveType = chFx.customWave ? chFx.waveType : waveTypeSelect.value;
     const slider = mixerSliders[waveType];
-    const waveVol = slider ? slider.value / 100 : 0.5;
-    state.gainNode.gain.value = waveVol;
+    state.waveGain = slider ? slider.value / 100 : 0.5;
+    applyChannelGain(state);
   }
 }
 

--- a/js/audio-engine.js
+++ b/js/audio-engine.js
@@ -168,7 +168,10 @@ async function playNotes(notes, bpm, seekOffset = 0) {
     // 波形別音量を初期値に適用
     const chWaveType = chFx.customWave ? chFx.waveType : document.getElementById('wave-type').value;
     const chWaveSlider = document.querySelector(`.mixer-channel[data-wave="${chWaveType}"] .mixer-vol`);
-    gainNode.gain.value = chWaveSlider ? chWaveSlider.value / 100 : 0.5;
+    const initWaveGain = chWaveSlider ? chWaveSlider.value / 100 : 0.5;
+    state.waveGain = initWaveGain;
+    state.playGate = 1;
+    gainNode.gain.value = initWaveGain;
 
     // --- チャンネル別FXノード (dry/wet方式) ---
 

--- a/js/visualizer.js
+++ b/js/visualizer.js
@@ -264,6 +264,15 @@ function updateChannelGains() {
   for (const [ch, state] of Object.entries(channelStates)) {
     if (!state.gainNode) continue;
     const shouldPlay = anySolo ? state.soloed && !state.muted : !state.muted;
-    state.gainNode.gain.value = shouldPlay ? 1 : 0;
+    state.playGate = shouldPlay ? 1 : 0;
+    applyChannelGain(state);
   }
+}
+
+// waveGain × playGate を gainNode に適用
+function applyChannelGain(state) {
+  if (!state.gainNode) return;
+  const waveGain = state.waveGain ?? 1;
+  const playGate = state.playGate ?? 1;
+  state.gainNode.gain.value = waveGain * playGate;
 }


### PR DESCRIPTION
## What
波形ミキサーの音量スライダーをチャンネルごとに適用。個別波形選択したチャンネルはその波形のスライダー値が反映されるように。

## Why
これまでmasterGainに「グローバル選択中の波形の音量×マスター音量」を掛けていたため、チャンネル個別で波形を変えても音量スライダーが連動しなかった。

## Changes
- `masterGain` はマスター音量のみ管理
- 各チャンネルの `gainNode` に波形別音量を適用
- `applyChannelWaveVolumes()` で全チャンネルのゲインをリアルタイム更新
- 波形スライダー変更・グローバル波形切替・個別波形切替時にすべて連動

## Risk
Low — 音声チェーンの接続構造は変更なし。ゲイン値の適用箇所のみ変更。