### PR TITLE
fix: move spectrumAnalyser after EQ/FX + audio chain diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,28 @@ https://orleans-house.github.io/midi-parser/
 2. 「再生」で再生開始
 3. 必要に応じて波形・音量を調整
 
+## Audio Signal Chain
+
+```
+[Per-Channel]
+  Osc → Envelope → ChGain(waveVol×playGate)
+    → ChDistortion(dry/wet)
+    → ChDelay(dry/wet)
+    → ChReverb(dry/wet)
+    → ChAnalyser
+
+[Master]
+  ChAnalyser(×16) → MasterGain(master vol)
+    → GlobalFilter → EQ(5-band)
+    → Distortion ─→ FX Trim ─→ SpectrumAnalyser(display)
+    → Delay → DelayWet ─┘         │
+    → Convolver → ReverbWet ─┘    ↓
+                                MasterAnalyser → destination
+
+[Metronome]
+  MetronomeOsc → Envelope → MetronomeGain → destination
+```
+
 ## Privacy / Security
 
 - このアプリは基本的にクライアントサイドで動作します

--- a/js/audio-engine.js
+++ b/js/audio-engine.js
@@ -53,7 +53,7 @@ async function playNotes(notes, bpm, seekOffset = 0) {
   window._masterGain = masterGain;
   window._audioCtxSampleRate = audioCtx.sampleRate;
 
-  // スペクトラム表示用Analyser (masterGain前に配置)
+  // スペクトラム表示用Analyser (fxTrim後に配置、EQ/FXの結果を反映)
   const spectrumAnalyser = audioCtx.createAnalyser();
   spectrumAnalyser.fftSize = 4096;
   spectrumAnalyser.smoothingTimeConstant = 0.8;
@@ -81,10 +81,8 @@ async function playNotes(notes, bpm, seekOffset = 0) {
     eqFilters.push(filter);
   });
 
-  // masterGain → EQ chain → analyser → destination
-  // masterGain → spectrumAnalyser (表示用、音声経路外)
-  // masterGain → globalFilter → EQ (フィルターは常に接続、OFF時はallpass的に動作)
-  masterGain.connect(spectrumAnalyser);
+  // masterGain → globalFilter → EQ → FX → fxTrim → spectrumAnalyser (表示用分岐)
+  //                                               → masterAnalyser → destination
   if (!window._globalFilterEnabled) {
     // OFF時: 高周波数のlowpassで実質素通し
     globalFilter.type = 'lowpass';
@@ -154,6 +152,7 @@ async function playNotes(notes, bpm, seekOffset = 0) {
   delayWet.connect(fxTrim);
   prevNode.connect(convolver);
   reverbWet.connect(fxTrim);
+  fxTrim.connect(spectrumAnalyser);
   fxTrim.connect(masterAnalyser);
   masterAnalyser.connect(audioCtx.destination);
   window._eqFilters = eqFilters;


### PR DESCRIPTION
## What
スペクトラムアナライザーをEQ/FXチェーンの後に移動。READMEにオーディオ信号チェーン図を追加。

## Why
`spectrumAnalyser` が `masterGain` 直後（EQ前）に接続されていたため、EQを操作してもスペクトラム表示が変化しなかった。

## Changes
- `spectrumAnalyser` の接続を `masterGain` → `fxTrim` 後に移動
- EQ・ディストーション・ディレイ・リバーブの効果がすべてスペクトラムに反映される
- READMEにPer-Channel / Master / Metronomの信号チェーン図を追加

## Risk
Low — `spectrumAnalyser` は表示専用で音声出力パスには影響なし。