### PR TITLE
test: E2Eテストカバレッジ拡充 (7 → 34テスト)

### DIFF
--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -397,20 +397,19 @@ test.describe('MIDI Parser App', () => {
 
   // ===== Drag & Drop =====
 
-  test('drag and drop zone is set up on body', async ({ page }) => {
-    // Verify the drop overlay exists
-    const overlay = page.locator('#drop-overlay');
-    // The overlay is created dynamically, check if body has dragover handler
-    // by triggering a dragenter event
+  test('drag overlay activates on dragenter with files', async ({ page }) => {
+    const overlay = page.locator('#drag-overlay');
+    await expect(overlay).not.toHaveClass(/active/);
+
+    // Simulate dragenter with Files type
     await page.evaluate(() => {
-      const event = new DragEvent('dragenter', { bubbles: true });
+      const dt = new DataTransfer();
+      dt.items.add(new File([''], 'test.mid', { type: 'audio/midi' }));
+      const event = new DragEvent('dragenter', { bubbles: true, dataTransfer: dt });
       document.body.dispatchEvent(event);
     });
-    await expect(overlay)
-      .toBeVisible({ timeout: 2000 })
-      .catch(() => {
-        // drop-overlay may or may not exist depending on implementation
-      });
+
+    await expect(overlay).toHaveClass(/active/, { timeout: 2000 });
   });
 
   // ===== Right Panel =====


### PR DESCRIPTION
## What
E2Eテストを7件から34件に拡充。

## 追加テスト
- **再生コントロール**: リピートボタントグル
- **波形ミキサー**: マスター音量表示、波形ボタン切替、グローバル波形→全チャンネルFX同期、波形音量表示、チャンネル個別波形
- **EQ**: 5バンド周波数検証、スライダー値表示（正負）
- **Filter XY**: パッドラベル初期値、マウス操作でラベル更新
- **Qスライダー**: デフォルト値、スライダー操作で表示更新
- **メトロノーム**: トグル有効化、音量表示、音色5種
- **チャンネルカード**: Mute/Soloボタントグル
- **FXモジュール**: 生成確認、3エフェクトトグル+スライダー連動、波形ボタン4種
- **ピアノロール**: MIDI読み込み後に表示
- **レイアウト**: スペクトラム・XYパッド・右パネル

## Why
既存テストはUIの初期状態確認のみだった。操作系の動作検証を網羅的に追加。

## Risk
Low — テストファイルの変更のみ。