### PR TITLE
fix: メトロノーム音色のリアルタイム切替対応

### DIFF
--- a/js/audio-engine.js
+++ b/js/audio-engine.js
@@ -54,10 +54,14 @@ async function playNotes(notes, bpm, seekOffset = 0) {
   let nextMetroBeat = startOffset;
   let metroBeatCount = 0;
 
-  function scheduleMetronome(horizon) {
+  // メトロノームは短い先読みで独立スケジュール（音色リアルタイム切替対応）
+  const METRO_LOOK_AHEAD = 0.3;
+
+  function scheduleMetronome() {
     if (!document.getElementById('metronome-on').checked) return;
     const metroType = document.getElementById('metronome-type').value;
-    while (nextMetroBeat < horizon) {
+    const metroHorizon = audioCtx.currentTime + METRO_LOOK_AHEAD;
+    while (nextMetroBeat < metroHorizon) {
       if (nextMetroBeat >= startOffset) {
         const isAccent = metroBeatCount % 4 === 0;
         createMetroClick(audioCtx, metronomeGain, nextMetroBeat, isAccent, metroType);
@@ -70,7 +74,7 @@ async function playNotes(notes, bpm, seekOffset = 0) {
   function scheduler() {
     if (!isPlaying || !audioCtx) return;
     const horizon = audioCtx.currentTime + LOOK_AHEAD;
-    scheduleMetronome(horizon);
+    scheduleMetronome();
 
     while (chunkIndex < notes.length) {
       const t = startOffset + notes[chunkIndex].startTime;


### PR DESCRIPTION
## What
メトロノームの先読み時間をメインスケジューラ（15秒）から独立させ、0.3秒の短い先読みに変更。

## Why
再生中にメトロノームの音色を切り替えても、先読み済み（最大15秒分）のクリック音が古い音色のまま再生され続ける問題があった。

## Risk
低。メトロノームのスケジューリングのみ変更。MIDIノートのスケジューリングには影響なし。スケジューラ間隔200msに対し先読み0.3秒で余裕あり。