### PR TITLE
fix: チャンネル別波形の描画ゲイン増幅

### DIFF
--- a/js/audio-output.js
+++ b/js/audio-output.js
@@ -110,9 +110,11 @@ function drawWaveforms() {
 
     const sliceWidth = canvas.width / bufferLength;
     let x = 0;
+    const chWaveGain = 3.0; // チャンネル波形の描画ゲイン
     for (let i = 0; i < bufferLength; i++) {
       const v = waveformChBufs[ch][i] / 128.0;
-      const y = (v * canvas.height) / 2;
+      const centered = (v - 1.0) * chWaveGain + 1.0;
+      const y = (centered * canvas.height) / 2;
       if (i === 0) ctx.moveTo(x, y);
       else ctx.lineTo(x, y);
       x += sliceWidth;


### PR DESCRIPTION
## What
チャンネル別波形の描画時に中心基準で3倍の増幅を適用。

## Why
チャンネル波形が小さく視認しづらかった。音声信号自体は変えず、描画のみ増幅することで視認性を改善。

## Risk
低。描画処理のみの変更で音声出力に影響なし。