### PR TITLE
fix: ホットキュージャンプ時にABループを解除

### DIFF
--- a/js/dj-controls.js
+++ b/js/dj-controls.js
@@ -23,7 +23,8 @@ document.getElementById('hot-cue-pads').addEventListener('click', (e) => {
     pad.classList.add('set');
     pad.title = `${time.toFixed(1)}s`;
   } else {
-    // Jump to cue
+    // Jump to cue（ABループは解除）
+    clearABLoop();
     stopPlayback();
     playNotesFrom(currentNotes, currentBpm, hotCues[slot]);
   }


### PR DESCRIPTION
## What
ホットキューでジャンプした際に `clearABLoop()` を呼び出してABループを解除する。

## Why
ABループ設定中にホットキューでジャンプすると、ループのsetTimeoutタイマーがクリアされずにズレたタイミングで発火し、ABループが正常に機能しなくなっていた。

## Risk
低。ホットキュージャンプ処理に1行追加のみ。