### PR TITLE
refactor: window.*共有stateをaudioStateモジュールに移行

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -11,6 +11,7 @@ import { detectKeyScale, extractChannelPrograms, extractNotes, MidiParser } from
 import { drawPianoRoll, invalidatePianoRollCache } from './piano-roll.js';
 import { addFilesToPlaylist, clearPlaylist } from './playlist.js';
 import { buildSF2PresetMap, SF2Parser } from './sf2-parser.js';
+import state from './state/audioState.js';
 import { applyChannelGain, buildChannelUI, detectChannels } from './visualizer.js';
 import { applyWaveform } from './waveforms.js';
 
@@ -45,22 +46,22 @@ masterVolume.addEventListener('input', () => {
 // 波形音量をチャンネルごとに適用 + マスター音量を masterGain に反映
 function applyCurrentWaveVolume() {
   const masterVol = masterVolume.value / 100;
-  if (window._masterGain) {
-    window._masterGain.gain.value = masterVol;
+  if (state._masterGain) {
+    state._masterGain.gain.value = masterVol;
   }
   applyChannelWaveVolumes();
 }
 
 // 各チャンネルの waveGain に波形別音量を適用
 function applyChannelWaveVolumes() {
-  if (typeof window.channelStates === 'undefined') return;
-  for (const [ch, state] of Object.entries(window.channelStates)) {
-    if (!state.gainNode) continue;
+  if (typeof state.channelStates === 'undefined') return;
+  for (const [ch, chState] of Object.entries(state.channelStates)) {
+    if (!chState.gainNode) continue;
     const chFx = getChannelFx(Number(ch));
     const waveType = chFx.waveType;
     const slider = mixerSliders[waveType];
-    state.waveGain = slider ? slider.value / 100 : 0.5;
-    applyChannelGain(state);
+    chState.waveGain = slider ? slider.value / 100 : 0.5;
+    applyChannelGain(chState);
   }
 }
 
@@ -81,15 +82,15 @@ function setActiveWave(newWave) {
   applyCurrentWaveVolume();
 
   // SF2モードを無効化（波形選択=オシレーターモード）
-  window._useSF2 = false;
+  state._useSF = false;
   const btnSF2 = document.getElementById('btn-load-sf2');
   if (btnSF2) btnSF2.classList.remove('active');
 
   // 全チャンネルの波形を一括変更（channelFxState全体 + currentChannels）
-  for (const ch of Object.keys(window.channelFxState)) {
-    window.channelFxState[ch].waveType = newWave;
+  for (const ch of Object.keys(state.channelFxState)) {
+    state.channelFxState[ch].waveType = newWave;
   }
-  for (const ch of window.currentChannels) {
+  for (const ch of state.currentChannels) {
     getChannelFx(ch).waveType = newWave;
   }
 
@@ -102,8 +103,8 @@ function setActiveWave(newWave) {
   applyChannelWaveVolumes();
 
   // 再生中のオシレーターの波形を変更
-  if (typeof window.scheduledNodes !== 'undefined') {
-    for (const osc of window.scheduledNodes) {
+  if (typeof state.scheduledNodes !== 'undefined') {
+    for (const osc of state.scheduledNodes) {
       try {
         if (osc.context) {
           applyWaveform(osc, newWave, osc.context);
@@ -148,11 +149,11 @@ const btnLoadSF2 = document.getElementById('btn-load-sf2');
 const sf2Input = document.getElementById('sf2-input');
 
 btnLoadSF2.addEventListener('click', () => {
-  if (window._sf2Data) {
+  if (state._sf) {
     // SF2読み込み済み: ON/OFFトグル
-    window._useSF2 = !window._useSF2;
-    btnLoadSF2.classList.toggle('active', window._useSF2);
-    if (window._useSF2) {
+    state._useSF = !state._useSF;
+    btnLoadSF2.classList.toggle('active', state._useSF);
+    if (state._useSF) {
       // SF2有効化: 波形ボタンのアクティブを解除
       for (const btn of Object.values(mixerBtns)) {
         btn.classList.remove('active');
@@ -161,8 +162,8 @@ btnLoadSF2.addEventListener('click', () => {
     } else {
       // SF2無効化: 現在の波形を再アクティブ化
       const currentWave =
-        Object.keys(window.channelFxState).length > 0
-          ? window.channelFxState[Object.keys(window.channelFxState)[0]]?.waveType || 'triangle'
+        Object.keys(state.channelFxState).length > 0
+          ? state.channelFxState[Object.keys(state.channelFxState)[0]]?.waveType || 'triangle'
           : 'triangle';
       if (mixerBtns[currentWave]) mixerBtns[currentWave].classList.add('active');
     }
@@ -188,10 +189,10 @@ sf2Input.addEventListener('change', () => {
     try {
       const parser = new SF2Parser(e.target.result);
       const sf2Data = parser.parse();
-      window._sf2Data = sf2Data;
-      window._sf2PresetMap = buildSF2PresetMap(sf2Data);
+      state._sf = sf2Data;
+      state._sf2PresetMap = buildSF2PresetMap(sf2Data);
       const sf2DisplayName = sf2Data.info.INAM || file.name.replace('.sf2', '');
-      window._useSF2 = true;
+      state._useSF = true;
       btnLoadSF2.title = `SF2: ${sf2DisplayName}`;
       btnLoadSF2.classList.add('active');
       const sf2NameEl = document.getElementById('sf2-name');
@@ -202,7 +203,7 @@ sf2Input.addEventListener('change', () => {
         btn.classList.remove('active');
       }
       document.getElementById('custom-waveform-select').value = '';
-      console.log(`SF2 loaded: ${sf2DisplayName}`, `Presets: ${Object.keys(window._sf2PresetMap).length}`);
+      console.log(`SF2 loaded: ${sf2DisplayName}`, `Presets: ${Object.keys(state._sf2PresetMap).length}`);
     } catch (err) {
       console.error('SF2 load error:', err);
       alert(`SF2読み込みエラー: ${err.message}`);
@@ -288,18 +289,18 @@ export function loadFiles(fileList) {
 
 export function processAudioFile(buffer, fileName) {
   stopPlayback();
-  window.audioFileMode = true;
-  window.audioFileBuffer = null;
+  state.audioFileMode = true;
+  state.audioFileBuffer = null;
   if (typeof resetDJControls === 'function') resetDJControls();
   if (typeof invalidatePianoRollCache === 'function') invalidatePianoRollCache();
 
   // 生バッファを保持（シーク用）
-  window._audioFileRawBuffer = buffer;
+  state._audioFileRawBuffer = buffer;
 
   // MIDIモードのデータをクリア
-  window.currentNotes = [];
-  window.currentChannels = [];
-  window.currentBpm = 0;
+  state.currentNotes = [];
+  state.currentChannels = [];
+  state.currentBpm = 0;
 
   // ファイル情報表示
   document.getElementById('info-filename').textContent = fileName;
@@ -327,9 +328,9 @@ export function processAudioFile(buffer, fileName) {
 
 export function processMidi(buffer, fileName) {
   stopPlayback();
-  window.audioFileMode = false;
-  window.audioFileBuffer = null;
-  window._audioFileRawBuffer = null;
+  state.audioFileMode = false;
+  state.audioFileBuffer = null;
+  state._audioFileRawBuffer = null;
   if (typeof resetDJControls === 'function') resetDJControls();
   if (typeof invalidatePianoRollCache === 'function') invalidatePianoRollCache();
 
@@ -337,14 +338,14 @@ export function processMidi(buffer, fileName) {
   const parsed = parser.parse();
   const { notes, tempo, bpm } = extractNotes(parsed);
 
-  window.currentNotes = notes;
-  window.currentBpm = bpm;
+  state.currentNotes = notes;
+  state.currentBpm = bpm;
 
   // チャンネルごとの楽器情報を抽出
-  window.channelPrograms = extractChannelPrograms(parsed);
+  state.channelPrograms = extractChannelPrograms(parsed);
 
   // チャンネル検出
-  window.currentChannels = detectChannels(notes);
+  state.currentChannels = detectChannels(notes);
 
   // ファイル情報表示
   document.getElementById('info-filename').textContent = fileName;
@@ -370,13 +371,13 @@ export function processMidi(buffer, fileName) {
   // テンポ表示（不要 — ファイル情報に表示済み）
 
   // チャンネルUI構築
-  buildChannelUI(window.currentChannels);
+  buildChannelUI(state.currentChannels);
   // 再生コントロール有効化
   btnPlay.disabled = false;
   btnStop.disabled = true;
 
   // 全体の長さを事前計算
-  window.currentTotalDuration = notes.length > 0 ? Math.max(...notes.map((n) => n.startTime + n.duration)) : 0;
+  state.currentTotalDuration = notes.length > 0 ? Math.max(...notes.map((n) => n.startTime + n.duration)) : 0;
 
   // 描画（表示後に実行）
   requestAnimationFrame(() => {
@@ -386,21 +387,21 @@ export function processMidi(buffer, fileName) {
 
 // 再生コントロール
 btnPlay.addEventListener('click', () => {
-  if (window.audioFileMode) {
-    if (window.isPlaying && !window.isPaused) {
+  if (state.audioFileMode) {
+    if (state.isPlaying && !state.isPaused) {
       pauseAudioFile();
-    } else if (window.isPlaying && window.isPaused) {
+    } else if (state.isPlaying && state.isPaused) {
       resumeAudioFile();
     } else {
-      playAudioFile(window._audioFileRawBuffer);
+      playAudioFile(state._audioFileRawBuffer);
     }
   } else {
-    if (window.isPlaying && !window.isPaused) {
+    if (state.isPlaying && !state.isPaused) {
       pausePlayback();
-    } else if (window.isPlaying && window.isPaused) {
+    } else if (state.isPlaying && state.isPaused) {
       resumePlayback();
     } else {
-      playNotes(window.currentNotes, window.currentBpm);
+      playNotes(state.currentNotes, state.currentBpm);
     }
   }
 });
@@ -409,8 +410,8 @@ btnStop.addEventListener('click', () => stopPlayback());
 // リピート
 const btnRepeat = document.getElementById('btn-repeat');
 btnRepeat.addEventListener('click', () => {
-  window.repeatEnabled = !window.repeatEnabled;
-  btnRepeat.classList.toggle('active', window.repeatEnabled);
+  state.repeatEnabled = !state.repeatEnabled;
+  btnRepeat.classList.toggle('active', state.repeatEnabled);
 });
 
 // EQ スライダーイベント
@@ -420,8 +421,8 @@ document.querySelectorAll('.eq-band').forEach((band, i) => {
   slider.addEventListener('input', () => {
     const val = Number(slider.value);
     valDisplay.textContent = val > 0 ? `+${val}` : `${val}`;
-    if (window._eqFilters?.[i]) {
-      window._eqFilters[i].gain.value = val;
+    if (state._eqFilters?.[i]) {
+      state._eqFilters[i].gain.value = val;
     }
   });
 });
@@ -444,8 +445,8 @@ document.addEventListener('click', (e) => {
     waveBtn.classList.add('active');
 
     // 再生中のオシレーターの波形を変更
-    if (typeof window.scheduledNodes !== 'undefined') {
-      for (const osc of window.scheduledNodes) {
+    if (typeof state.scheduledNodes !== 'undefined') {
+      for (const osc of state.scheduledNodes) {
         try {
           if (osc._channel === ch) {
             if (osc.context) {
@@ -475,18 +476,18 @@ document.addEventListener('change', (e) => {
     slider.disabled = !e.target.checked;
     chFx[fx].enabled = e.target.checked;
 
-    const state = window.channelStates[ch];
-    if (state?.fxNodes) {
+    const chState = state.channelStates[ch];
+    if (chState?.fxNodes) {
       if (fx === 'distortion') {
-        state.fxNodes.distDry.gain.value = e.target.checked ? 0 : 1;
-        state.fxNodes.distWet.gain.value = e.target.checked ? 1 : 0;
+        chState.fxNodes.distDry.gain.value = e.target.checked ? 0 : 1;
+        chState.fxNodes.distWet.gain.value = e.target.checked ? 1 : 0;
         if (e.target.checked) {
-          updateDistortionCurve(state.fxNodes.distortion, chFx.distortion.amount);
+          updateDistortionCurve(chState.fxNodes.distortion, chFx.distortion.amount);
         }
       } else if (fx === 'delay') {
-        state.fxNodes.delayWet.gain.value = e.target.checked ? 0.5 : 0;
+        chState.fxNodes.delayWet.gain.value = e.target.checked ? 0.5 : 0;
       } else if (fx === 'reverb') {
-        state.fxNodes.reverbWet.gain.value = e.target.checked ? chFx.reverb.mix / 100 : 0;
+        chState.fxNodes.reverbWet.gain.value = e.target.checked ? chFx.reverb.mix / 100 : 0;
       }
     }
   }
@@ -501,21 +502,21 @@ document.addEventListener('input', (e) => {
     const valDisplay = e.target.closest('.fx-mod-row').querySelector('.ch-fx-val');
     valDisplay.textContent = e.target.value;
 
-    const state = window.channelStates[ch];
+    const chState = state.channelStates[ch];
     if (fx === 'distortion') {
       chFx.distortion.amount = Number(e.target.value);
-      if (state?.fxNodes && chFx.distortion.enabled) {
-        updateDistortionCurve(state.fxNodes.distortion, chFx.distortion.amount);
+      if (chState?.fxNodes && chFx.distortion.enabled) {
+        updateDistortionCurve(chState.fxNodes.distortion, chFx.distortion.amount);
       }
     } else if (fx === 'delay') {
       chFx.delay.time = Number(e.target.value);
-      if (state?.fxNodes) {
-        state.fxNodes.delay.delayTime.value = Number(e.target.value) / 1000;
+      if (chState?.fxNodes) {
+        chState.fxNodes.delay.delayTime.value = Number(e.target.value) / 1000;
       }
     } else if (fx === 'reverb') {
       chFx.reverb.mix = Number(e.target.value);
-      if (state?.fxNodes && chFx.reverb.enabled) {
-        state.fxNodes.reverbWet.gain.value = Number(e.target.value) / 100;
+      if (chState?.fxNodes && chFx.reverb.enabled) {
+        chState.fxNodes.reverbWet.gain.value = Number(e.target.value) / 100;
       }
     }
   }
@@ -538,7 +539,7 @@ export function startSpectrumDraw() {
   }
 
   spectrumTimer = setInterval(() => {
-    const analyser = window._spectrumAnalyser;
+    const analyser = state._spectrumAnalyser;
     if (!analyser) return;
 
     const w = spectrumCanvas.width;
@@ -555,7 +556,7 @@ export function startSpectrumDraw() {
     specCtx.fillRect(0, 0, w, h);
 
     // スペクトラムバー (対数スケール、4px幅で間引き)
-    const nyquist = (window._audioCtxSampleRate || 48000) / 2;
+    const nyquist = (state._audioCtxSampleRate || 48000) / 2;
     const minFreq = FREQ_MIN;
     const maxFreq = FREQ_MAX;
     const barWidth = 4;
@@ -575,8 +576,8 @@ export function startSpectrumDraw() {
     specCtx.globalAlpha = 1;
 
     // HPF/LPFカットオフ線
-    const hpfF = window._hpfFreq || 20;
-    const lpfF = window._lpfFreq || 20000;
+    const hpfF = state._hpfFreq || 20;
+    const lpfF = state._lpfFreq || 20000;
     specCtx.lineWidth = 2;
     specCtx.setLineDash([4, 4]);
     if (hpfF > 25) {
@@ -604,8 +605,8 @@ export function startSpectrumDraw() {
     specCtx.setLineDash([]);
 
     // 周波数シフト時: 基準線（元の位置）とシフト後の位置を表示
-    const freqShift = window._freqShift || 0;
-    const pitchShift = window._pitchShift || 0;
+    const freqShift = state._freqShift || 0;
+    const pitchShift = state._pitchShift || 0;
     const anyShift = freqShift !== 0 || pitchShift !== 0;
     {
       const noteNames = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
@@ -683,18 +684,18 @@ const xyHpfLabel = document.getElementById('xy-hpf-label');
 const xyLpfLabel = document.getElementById('xy-lpf-label');
 let xyDragging = false;
 let filterMode = 'hpf-lpf';
-window._filterMode = filterMode;
+state._filterMode = filterMode;
 
 // 初期値
-window._hpfFreq = 20;
-window._lpfFreq = 20000;
-window._bpFreq = 1000;
-window._bpQ = 1;
-window._notchFreq = 1000;
-window._notchQ = 1;
-window._peakFreq = 1000;
-window._peakQ = 1;
-window._peakGain = 0;
+state._hpfFreq = 20;
+state._lpfFreq = 20000;
+state._bpFreq = 1000;
+state._bpQ = 1;
+state._notchFreq = 1000;
+state._notchQ = 1;
+state._peakFreq = 1000;
+state._peakQ = 1;
+state._peakGain = 0;
 // 初期化後にチェーン構築を通知（audio-master.js側で_switchFilterChainが設定される）
 
 // フィルターモード切替
@@ -702,13 +703,13 @@ const filterModeBtns = document.querySelectorAll('.filter-mode-btn');
 for (const btn of filterModeBtns) {
   btn.addEventListener('click', () => {
     filterMode = btn.dataset.mode;
-    window._filterMode = filterMode;
+    state._filterMode = filterMode;
     for (const b of filterModeBtns) {
       b.classList.toggle('active', b === btn);
     }
     // モード変更時にフィルターチェーンを切替・リセット
     resetFilterBypass();
-    if (window._switchFilterChain) window._switchFilterChain(filterMode);
+    if (state._switchFilterChain) state._switchFilterChain(filterMode);
     const rect = xyPad.getBoundingClientRect();
     drawXYPad(rect.width / 2, rect.height / 2, rect.width, rect.height);
   });
@@ -716,30 +717,30 @@ for (const btn of filterModeBtns) {
 
 function resetFilterBypass() {
   // HPF/LPFをデフォルトに戻す
-  window._hpfFreq = 20;
-  window._lpfFreq = 20000;
-  if (window._hpf) window._hpf.frequency.value = 20;
-  if (window._lpf) window._lpf.frequency.value = 20000;
+  state._hpfFreq = 20;
+  state._lpfFreq = 20000;
+  if (state._hpf) state._hpf.frequency.value = 20;
+  if (state._lpf) state._lpf.frequency.value = 20000;
   // 各フィルターのパラメータをデフォルトに戻す
-  window._bpFreq = 1000;
-  window._bpQ = 1;
-  if (window._bandpass) {
-    window._bandpass.frequency.value = 1000;
-    window._bandpass.Q.value = 1;
+  state._bpFreq = 1000;
+  state._bpQ = 1;
+  if (state._bandpass) {
+    state._bandpass.frequency.value = 1000;
+    state._bandpass.Q.value = 1;
   }
-  window._notchFreq = 1000;
-  window._notchQ = 1;
-  if (window._notch) {
-    window._notch.frequency.value = 1000;
-    window._notch.Q.value = 1;
+  state._notchFreq = 1000;
+  state._notchQ = 1;
+  if (state._notch) {
+    state._notch.frequency.value = 1000;
+    state._notch.Q.value = 1;
   }
-  window._peakFreq = 1000;
-  window._peakQ = 1;
-  window._peakGain = 0;
-  if (window._peaking) {
-    window._peaking.frequency.value = 1000;
-    window._peaking.Q.value = 1;
-    window._peaking.gain.value = 0;
+  state._peakFreq = 1000;
+  state._peakQ = 1;
+  state._peakGain = 0;
+  if (state._peaking) {
+    state._peaking.frequency.value = 1000;
+    state._peaking.Q.value = 1;
+    state._peaking.gain.value = 0;
   }
   xyHpfLabel.textContent = '';
   xyLpfLabel.textContent = '';
@@ -774,41 +775,41 @@ function applyXYFilter(x, y) {
 
   if (filterMode === 'hpf-lpf') {
     const { hpfFreq, lpfFreq } = xyPosToFreqs(cx, cy, rect.width, rect.height);
-    window._hpfFreq = hpfFreq;
-    window._lpfFreq = lpfFreq;
-    if (window._hpf) window._hpf.frequency.value = hpfFreq;
-    if (window._lpf) window._lpf.frequency.value = lpfFreq;
+    state._hpfFreq = hpfFreq;
+    state._lpfFreq = lpfFreq;
+    if (state._hpf) state._hpf.frequency.value = hpfFreq;
+    if (state._lpf) state._lpf.frequency.value = lpfFreq;
     xyHpfLabel.textContent = `HPF: ${formatFreq(hpfFreq)}`;
     xyLpfLabel.textContent = `LPF: ${formatFreq(lpfFreq)}`;
   } else if (filterMode === 'bandpass') {
     const { freq, q } = xyPosToFreqQ(cx, cy, rect.width, rect.height);
-    window._bpFreq = freq;
-    window._bpQ = q;
-    if (window._bandpass) {
-      window._bandpass.frequency.value = freq;
-      window._bandpass.Q.value = q;
+    state._bpFreq = freq;
+    state._bpQ = q;
+    if (state._bandpass) {
+      state._bandpass.frequency.value = freq;
+      state._bandpass.Q.value = q;
     }
     xyHpfLabel.textContent = `Freq: ${formatFreq(freq)}`;
     xyLpfLabel.textContent = `Q: ${q.toFixed(1)}`;
   } else if (filterMode === 'notch') {
     const { freq, q } = xyPosToFreqQ(cx, cy, rect.width, rect.height);
-    window._notchFreq = freq;
-    window._notchQ = q;
-    if (window._notch) {
-      window._notch.frequency.value = freq;
-      window._notch.Q.value = q;
+    state._notchFreq = freq;
+    state._notchQ = q;
+    if (state._notch) {
+      state._notch.frequency.value = freq;
+      state._notch.Q.value = q;
     }
     xyHpfLabel.textContent = `Freq: ${formatFreq(freq)}`;
     xyLpfLabel.textContent = `Q: ${q.toFixed(1)}`;
   } else if (filterMode === 'peaking') {
     const { freq, gain } = xyPosToFreqGain(cx, cy, rect.width, rect.height);
-    window._peakFreq = freq;
-    window._peakGain = gain;
-    window._peakQ = 2;
-    if (window._peaking) {
-      window._peaking.frequency.value = freq;
-      window._peaking.gain.value = gain;
-      window._peaking.Q.value = 2;
+    state._peakFreq = freq;
+    state._peakGain = gain;
+    state._peakQ = 2;
+    if (state._peaking) {
+      state._peaking.frequency.value = freq;
+      state._peaking.gain.value = gain;
+      state._peaking.Q.value = 2;
     }
     xyHpfLabel.textContent = `Freq: ${formatFreq(freq)}`;
     xyLpfLabel.textContent = `Gain: ${gain > 0 ? '+' : ''}${gain.toFixed(1)}dB`;
@@ -916,12 +917,12 @@ const lpfQValue = document.getElementById('lpf-q-value');
 hpfQSlider.addEventListener('input', () => {
   const q = Number(hpfQSlider.value);
   hpfQValue.textContent = q.toFixed(1);
-  if (window._hpf) window._hpf.Q.value = q;
+  if (state._hpf) state._hpf.Q.value = q;
 });
 lpfQSlider.addEventListener('input', () => {
   const q = Number(lpfQSlider.value);
   lpfQValue.textContent = q.toFixed(1);
-  if (window._lpf) window._lpf.Q.value = q;
+  if (state._lpf) state._lpf.Q.value = q;
 });
 
 // メトロノーム
@@ -929,18 +930,18 @@ lpfQSlider.addEventListener('input', () => {
 const pitchShiftSlider = document.getElementById('pitch-shift');
 const pitchShiftVal = document.getElementById('pitch-shift-val');
 const pitchShiftReset = document.getElementById('pitch-shift-reset');
-window._pitchShift = 0;
+state._pitchShift = 0;
 
 pitchShiftSlider.addEventListener('input', () => {
   const v = Number(pitchShiftSlider.value);
-  window._pitchShift = v;
+  state._pitchShift = v;
   pitchShiftVal.textContent = `${v >= 0 ? '+' : ''}${v} st`;
   if (typeof applyFreqShiftToActive === 'function') applyFreqShiftToActive();
 });
 
 pitchShiftReset.addEventListener('click', () => {
   pitchShiftSlider.value = 0;
-  window._pitchShift = 0;
+  state._pitchShift = 0;
   pitchShiftVal.textContent = '0 st';
   if (typeof applyFreqShiftToActive === 'function') applyFreqShiftToActive();
 });
@@ -949,18 +950,18 @@ pitchShiftReset.addEventListener('click', () => {
 const freqShiftSlider = document.getElementById('freq-shift');
 const freqShiftVal = document.getElementById('freq-shift-val');
 const freqShiftReset = document.getElementById('freq-shift-reset');
-window._freqShift = 0;
+state._freqShift = 0;
 
 freqShiftSlider.addEventListener('input', () => {
   const v = Number(freqShiftSlider.value);
-  window._freqShift = v;
+  state._freqShift = v;
   freqShiftVal.textContent = `${v >= 0 ? '+' : ''}${v} Hz`;
   if (typeof applyFreqShiftToActive === 'function') applyFreqShiftToActive();
 });
 
 freqShiftReset.addEventListener('click', () => {
   freqShiftSlider.value = 0;
-  window._freqShift = 0;
+  state._freqShift = 0;
   freqShiftVal.textContent = '0 Hz';
   if (typeof applyFreqShiftToActive === 'function') applyFreqShiftToActive();
 });
@@ -971,10 +972,10 @@ const scaleKey = document.getElementById('scale-key');
 const scaleFrom = document.getElementById('scale-from');
 const scaleTo = document.getElementById('scale-to');
 
-window._scaleConvert = { enabled: false, key: 0, from: 'major', to: 'minor' };
+state._scaleConvert = { enabled: false, key: 0, from: 'major', to: 'minor' };
 
 export function updateScaleConvert() {
-  window._scaleConvert = {
+  state._scaleConvert = {
     enabled: scaleConvertOn.checked,
     key: Number(scaleKey.value),
     from: scaleFrom.value,
@@ -998,15 +999,15 @@ const metronomeType = document.getElementById('metronome-type');
 metronomeOn.addEventListener('change', () => {
   metronomeVol.disabled = !metronomeOn.checked;
   metronomeType.disabled = !metronomeOn.checked;
-  if (window._metronomeGain) {
-    window._metronomeGain.gain.value = metronomeOn.checked ? Number(metronomeVol.value) / 100 : 0;
+  if (state._metronomeGain) {
+    state._metronomeGain.gain.value = metronomeOn.checked ? Number(metronomeVol.value) / 100 : 0;
   }
 });
 
 metronomeVol.addEventListener('input', () => {
   metronomeVolVal.textContent = `${metronomeVol.value}%`;
-  if (window._metronomeGain && metronomeOn.checked) {
-    window._metronomeGain.gain.value = Number(metronomeVol.value) / 100;
+  if (state._metronomeGain && metronomeOn.checked) {
+    state._metronomeGain.gain.value = Number(metronomeVol.value) / 100;
   }
 });
 
@@ -1019,17 +1020,17 @@ const limiterKneeVal = document.getElementById('limiter-knee-val');
 const limiterReduction = document.getElementById('limiter-reduction');
 
 limiterOn.addEventListener('change', () => {
-  applyLimiterParams(window._limiter);
+  applyLimiterParams(state._limiter);
 });
 
 limiterThreshold.addEventListener('input', () => {
   limiterThresholdVal.textContent = `${limiterThreshold.value} dB`;
-  applyLimiterParams(window._limiter);
+  applyLimiterParams(state._limiter);
 });
 
 limiterKnee.addEventListener('input', () => {
   limiterKneeVal.textContent = `${limiterKnee.value} dB`;
-  applyLimiterParams(window._limiter);
+  applyLimiterParams(state._limiter);
 });
 
 // リミッターのゲインリダクション表示
@@ -1038,8 +1039,8 @@ let limiterMeterTimer = null;
 export function startLimiterMeter() {
   if (limiterMeterTimer) return;
   limiterMeterTimer = setInterval(() => {
-    if (window._limiter && !window._limiterBypassed) {
-      const reduction = window._limiter.reduction;
+    if (state._limiter && !state._limiterBypassed) {
+      const reduction = state._limiter.reduction;
       limiterReduction.textContent = `Reduction: ${reduction.toFixed(1)} dB`;
     } else {
       limiterReduction.textContent = 'Reduction: OFF';
@@ -1066,23 +1067,23 @@ masterReverbOn.addEventListener('change', () => {
   const on = masterReverbOn.checked;
   masterReverbMix.disabled = !on;
   masterReverbDecay.disabled = !on;
-  if (window._masterReverbWet) {
-    window._masterReverbWet.gain.value = on ? Number(masterReverbMix.value) / 100 : 0;
+  if (state._masterReverbWet) {
+    state._masterReverbWet.gain.value = on ? Number(masterReverbMix.value) / 100 : 0;
   }
 });
 
 masterReverbMix.addEventListener('input', () => {
   masterReverbMixVal.textContent = `${masterReverbMix.value}%`;
-  if (window._masterReverbWet && masterReverbOn.checked) {
-    window._masterReverbWet.gain.value = Number(masterReverbMix.value) / 100;
+  if (state._masterReverbWet && masterReverbOn.checked) {
+    state._masterReverbWet.gain.value = Number(masterReverbMix.value) / 100;
   }
 });
 
 masterReverbDecay.addEventListener('input', () => {
   const decay = Number(masterReverbDecay.value) / 10;
   masterReverbDecayVal.textContent = `${decay.toFixed(1)}s`;
-  if (window._masterReverbConvolver && window.audioCtx) {
-    window._masterReverbConvolver.buffer = createReverbIR(window.audioCtx, decay, 2);
+  if (state._masterReverbConvolver && state.audioCtx) {
+    state._masterReverbConvolver.buffer = createReverbIR(state.audioCtx, decay, 2);
   }
 });
 
@@ -1100,31 +1101,31 @@ masterChorusOn.addEventListener('change', () => {
   masterChorusRate.disabled = !on;
   masterChorusDepth.disabled = !on;
   masterChorusMix.disabled = !on;
-  if (window._masterChorusWet) {
-    window._masterChorusWet.gain.value = on ? Number(masterChorusMix.value) / 100 : 0;
+  if (state._masterChorusWet) {
+    state._masterChorusWet.gain.value = on ? Number(masterChorusMix.value) / 100 : 0;
   }
 });
 
 masterChorusRate.addEventListener('input', () => {
   const rate = Number(masterChorusRate.value) / 10;
   masterChorusRateVal.textContent = `${rate.toFixed(1)} Hz`;
-  if (window._masterChorusLfo) {
-    window._masterChorusLfo.frequency.value = rate;
+  if (state._masterChorusLfo) {
+    state._masterChorusLfo.frequency.value = rate;
   }
 });
 
 masterChorusDepth.addEventListener('input', () => {
   const depth = Number(masterChorusDepth.value);
   masterChorusDepthVal.textContent = `${depth} ms`;
-  if (window._masterChorusLfoGain) {
-    window._masterChorusLfoGain.gain.value = depth / 1000;
+  if (state._masterChorusLfoGain) {
+    state._masterChorusLfoGain.gain.value = depth / 1000;
   }
 });
 
 masterChorusMix.addEventListener('input', () => {
   masterChorusMixVal.textContent = `${masterChorusMix.value}%`;
-  if (window._masterChorusWet && masterChorusOn.checked) {
-    window._masterChorusWet.gain.value = Number(masterChorusMix.value) / 100;
+  if (state._masterChorusWet && masterChorusOn.checked) {
+    state._masterChorusWet.gain.value = Number(masterChorusMix.value) / 100;
   }
 });
 

--- a/js/audio-channel.js
+++ b/js/audio-channel.js
@@ -4,9 +4,10 @@
 
 import { createReverbIR, updateDistortionCurve } from './audio-master.js';
 import { getChannelFx } from './globals.js';
+import state from './state/audioState.js';
 
 export function buildChannelChain(audioCtx, ch, masterGain) {
-  const state = window.channelStates[ch];
+  const chState = state.channelStates[ch];
   const chFx = getChannelFx(ch);
 
   const gainNode = audioCtx.createGain();
@@ -14,8 +15,8 @@ export function buildChannelChain(audioCtx, ch, masterGain) {
   const chWaveType = chFx.waveType;
   const chWaveSlider = document.querySelector(`.mixer-channel[data-wave="${chWaveType}"] .mixer-vol`);
   const initWaveGain = chWaveSlider ? chWaveSlider.value / 100 : 0.5;
-  state.waveGain = initWaveGain;
-  state.playGate = 1;
+  chState.waveGain = initWaveGain;
+  chState.playGate = 1;
   gainNode.gain.value = initWaveGain;
 
   // --- チャンネル別FXノード (dry/wet方式) ---
@@ -83,9 +84,9 @@ export function buildChannelChain(audioCtx, ch, masterGain) {
   chReverbMerge.connect(analyser);
   analyser.connect(masterGain);
 
-  state.gainNode = gainNode;
-  state.analyser = analyser;
-  state.fxNodes = {
+  chState.gainNode = gainNode;
+  chState.analyser = analyser;
+  chState.fxNodes = {
     distortion: chDistNode,
     distDry: chDistDry,
     distWet: chDistWet,

--- a/js/audio-engine.js
+++ b/js/audio-engine.js
@@ -17,6 +17,7 @@ import { buildMetronome, createMetroClick } from './audio-source.js';
 import { getChannelFx } from './globals.js';
 import { midiToFreq, remapNote } from './midi-parser.js';
 import { clearSF2BufferCache, findSF2Sample, getSF2AudioBuffer } from './sf2-parser.js';
+import state from './state/audioState.js';
 import { updateChannelGains } from './visualizer.js';
 import { applyWaveform, clearPeriodicWaveCache } from './waveforms.js';
 
@@ -26,8 +27,8 @@ let stopTimerId = null;
 
 // ピッチ/周波数/スケール変更時に再生中のノードを即時更新
 export function applyFreqShiftToActive() {
-  const pitchShift = window._pitchShift || 0;
-  for (const node of window.scheduledNodes) {
+  const pitchShift = state._pitchShift || 0;
+  for (const node of state.scheduledNodes) {
     if (node._baseMidi == null) continue;
     try {
       if (node._isSF2) {
@@ -45,14 +46,14 @@ export function applyFreqShiftToActive() {
 
 export async function playNotes(notes, bpm, seekOffset = 0) {
   stopPlayback();
-  window.audioCtx = new (window.AudioContext || window.webkitAudioContext)();
-  if (window.audioCtx.state === 'suspended') {
-    await window.audioCtx.resume();
+  state.audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+  if (state.audioCtx.state === 'suspended') {
+    await state.audioCtx.resume();
   }
-  window.isPlaying = true;
-  window.scheduledNodes = [];
+  state.isPlaying = true;
+  state.scheduledNodes = [];
 
-  const audioCtx = window.audioCtx;
+  const audioCtx = state.audioCtx;
 
   // === Master層 ===
   const { masterGain, eqOut } = buildMasterChain(audioCtx);
@@ -61,7 +62,7 @@ export async function playNotes(notes, bpm, seekOffset = 0) {
   buildOutputChain(audioCtx, eqOut);
 
   // === Channel層 ===
-  for (const ch of window.currentChannels) {
+  for (const ch of state.currentChannels) {
     buildChannelChain(audioCtx, ch, masterGain);
   }
 
@@ -101,7 +102,7 @@ export async function playNotes(notes, bpm, seekOffset = 0) {
   }
 
   function scheduler() {
-    if (!window.isPlaying || !window.audioCtx) return;
+    if (!state.isPlaying || !state.audioCtx) return;
     const horizon = audioCtx.currentTime + LOOK_AHEAD;
     scheduleMetronome();
 
@@ -116,11 +117,11 @@ export async function playNotes(notes, bpm, seekOffset = 0) {
       // SF2モード: サンプルベース再生
       let sourceNode;
 
-      if (window._useSF2 && window._sf2Data && window._sf2PresetMap) {
-        const sf2Data = window._sf2Data;
-        const sf2PresetMap = window._sf2PresetMap;
+      if (state._useSF && state._sf && state._sf2PresetMap) {
+        const sf2Data = state._sf;
+        const sf2PresetMap = state._sf2PresetMap;
         const bank = n.channel === 9 ? 128 : 0; // Ch10=ドラム
-        const program = window.channelPrograms[n.channel] || 0;
+        const program = state.channelPrograms[n.channel] || 0;
         const sample = findSF2Sample(sf2Data, sf2PresetMap, bank, program, n.note, n.velocity);
 
         if (sample) {
@@ -131,7 +132,7 @@ export async function playNotes(notes, bpm, seekOffset = 0) {
 
             // スケール変換 + ピッチシフト適用
             const remapped = remapNote(n.note);
-            const pitchShift = window._pitchShift || 0;
+            const pitchShift = state._pitchShift || 0;
             const semitones = remapped - sample.rootKey + sample.tuning + pitchShift;
             src.playbackRate.value = 2 ** (semitones / 12);
 
@@ -154,7 +155,7 @@ export async function playNotes(notes, bpm, seekOffset = 0) {
             env.gain.linearRampToValueAtTime(0, t + dur);
 
             src.connect(env);
-            const chState = window.channelStates[n.channel];
+            const chState = state.channelStates[n.channel];
             if (chState?.gainNode) {
               env.connect(chState.gainNode);
             } else {
@@ -191,7 +192,7 @@ export async function playNotes(notes, bpm, seekOffset = 0) {
         env.gain.linearRampToValueAtTime(0, t + dur);
 
         osc.connect(env);
-        const chState = window.channelStates[n.channel];
+        const chState = state.channelStates[n.channel];
         if (chState?.gainNode) {
           env.connect(chState.gainNode);
         } else {
@@ -204,11 +205,11 @@ export async function playNotes(notes, bpm, seekOffset = 0) {
         sourceNode = osc;
       }
 
-      window.scheduledNodes.push(sourceNode);
+      state.scheduledNodes.push(sourceNode);
       chunkIndex++;
     }
 
-    if (chunkIndex < notes.length && window.isPlaying) {
+    if (chunkIndex < notes.length && state.isPlaying) {
       schedulerTimer = setTimeout(scheduler, CHECK_INTERVAL);
     }
   }
@@ -218,7 +219,7 @@ export async function playNotes(notes, bpm, seekOffset = 0) {
   // 再生終了検知
   const totalDuration = notes.length > 0 ? Math.max(...notes.map((n) => n.startTime + n.duration)) : 0;
 
-  if (seekOffset === 0) window.currentTotalDuration = totalDuration;
+  if (seekOffset === 0) state.currentTotalDuration = totalDuration;
 
   const btnPlay = document.getElementById('btn-play');
   const btnStop = document.getElementById('btn-stop');
@@ -233,20 +234,20 @@ export async function playNotes(notes, bpm, seekOffset = 0) {
   // シークバー表示・設定
   const posDisplay = document.getElementById('position-display');
   const startReal = performance.now();
-  window.playbackStartReal = startReal;
-  window.playbackStartOffset = seekOffset;
+  state.playbackStartReal = startReal;
+  state.playbackStartOffset = seekOffset;
 
   animationTimer = setInterval(() => {
-    const elapsed = (performance.now() - startReal - window.pauseDuration) / 1000 + seekOffset;
-    posDisplay.textContent = `${elapsed.toFixed(1)}s / ${window.currentTotalDuration.toFixed(1)}s`;
+    const elapsed = (performance.now() - startReal - state.pauseDuration) / 1000 + seekOffset;
+    posDisplay.textContent = `${elapsed.toFixed(1)}s / ${state.currentTotalDuration.toFixed(1)}s`;
     if (typeof window.updatePlayhead === 'function') window.updatePlayhead(elapsed);
   }, 100);
 
   stopTimerId = setTimeout(
     () => {
-      if (window.isPlaying) {
-        if (window.repeatEnabled && window.currentNotes.length > 0) {
-          playNotes(window.currentNotes, window.currentBpm);
+      if (state.isPlaying) {
+        if (state.repeatEnabled && state.currentNotes.length > 0) {
+          playNotes(state.currentNotes, state.currentBpm);
         } else {
           stopPlayback();
           if (typeof window.playNextTrack === 'function') window.playNextTrack();
@@ -258,10 +259,10 @@ export async function playNotes(notes, bpm, seekOffset = 0) {
 }
 
 export function pausePlayback() {
-  if (!window.isPlaying || !window.audioCtx || window.isPaused) return;
-  window.isPaused = true;
-  window.pauseStartTime = performance.now();
-  window.audioCtx.suspend();
+  if (!state.isPlaying || !state.audioCtx || state.isPaused) return;
+  state.isPaused = true;
+  state.pauseStartTime = performance.now();
+  state.audioCtx.suspend();
   if (animationTimer) {
     clearInterval(animationTimer);
     animationTimer = null;
@@ -278,24 +279,24 @@ export function pausePlayback() {
 }
 
 export function resumePlayback() {
-  if (!window.isPlaying || !window.audioCtx || !window.isPaused) return;
-  window.isPaused = false;
-  window.pauseDuration += performance.now() - window.pauseStartTime;
-  window.audioCtx.resume();
+  if (!state.isPlaying || !state.audioCtx || !state.isPaused) return;
+  state.isPaused = false;
+  state.pauseDuration += performance.now() - state.pauseStartTime;
+  state.audioCtx.resume();
   const posDisplay = document.getElementById('position-display');
   animationTimer = setInterval(() => {
     const elapsed =
-      (performance.now() - window.playbackStartReal - window.pauseDuration) / 1000 + window.playbackStartOffset;
-    posDisplay.textContent = `${elapsed.toFixed(1)}s / ${window.currentTotalDuration.toFixed(1)}s`;
+      (performance.now() - state.playbackStartReal - state.pauseDuration) / 1000 + state.playbackStartOffset;
+    posDisplay.textContent = `${elapsed.toFixed(1)}s / ${state.currentTotalDuration.toFixed(1)}s`;
     if (typeof window.updatePlayhead === 'function') window.updatePlayhead(elapsed);
   }, 100);
   const currentElapsed =
-    (performance.now() - window.playbackStartReal - window.pauseDuration) / 1000 + window.playbackStartOffset;
-  const remaining = window.currentTotalDuration - currentElapsed;
+    (performance.now() - state.playbackStartReal - state.pauseDuration) / 1000 + state.playbackStartOffset;
+  const remaining = state.currentTotalDuration - currentElapsed;
   if (remaining > 0) {
     stopTimerId = setTimeout(
       () => {
-        if (window.isPlaying) stopPlayback();
+        if (state.isPlaying) stopPlayback();
       },
       (remaining + 1.0) * 1000,
     );
@@ -309,10 +310,10 @@ export function resumePlayback() {
 export function stopPlayback() {
   if (typeof window.stopSpectrumDraw === 'function') window.stopSpectrumDraw();
   if (typeof window.stopLimiterMeter === 'function') window.stopLimiterMeter();
-  window.isPaused = false;
-  window.pauseDuration = 0;
-  window.pauseStartTime = 0;
-  window.isPlaying = false;
+  state.isPaused = false;
+  state.pauseDuration = 0;
+  state.pauseStartTime = 0;
+  state.isPlaying = false;
   if (typeof window.clearLoopTimer === 'function') window.clearLoopTimer();
   if (stopTimerId) {
     clearTimeout(stopTimerId);
@@ -327,29 +328,29 @@ export function stopPlayback() {
     animationTimer = null;
   }
   // オーディオファイルソースの停止
-  if (window.audioFileSource) {
+  if (state.audioFileSource) {
     try {
-      window.audioFileSource.stop();
+      state.audioFileSource.stop();
     } catch {}
-    window.audioFileSource = null;
+    state.audioFileSource = null;
   }
 
-  for (const osc of window.scheduledNodes) {
+  for (const osc of state.scheduledNodes) {
     try {
       osc.stop();
     } catch {}
   }
-  window.scheduledNodes = [];
+  state.scheduledNodes = [];
   // チャンネルオーディオノードのクリーンアップ
-  for (const ch of Object.keys(window.channelStates)) {
-    window.channelStates[ch].gainNode = null;
-    window.channelStates[ch].analyser = null;
+  for (const ch of Object.keys(state.channelStates)) {
+    state.channelStates[ch].gainNode = null;
+    state.channelStates[ch].analyser = null;
   }
-  if (window.audioCtx) {
-    window.audioCtx.close().catch(() => {});
+  if (state.audioCtx) {
+    state.audioCtx.close().catch(() => {});
     clearPeriodicWaveCache();
     clearSF2BufferCache();
-    window.audioCtx = null;
+    state.audioCtx = null;
   }
   const btnPlay = document.getElementById('btn-play');
   const btnStop = document.getElementById('btn-stop');

--- a/js/audio-file-engine.js
+++ b/js/audio-file-engine.js
@@ -9,29 +9,30 @@
 import { stopPlayback } from './audio-engine.js';
 import { buildMasterChain } from './audio-master.js';
 import { buildOutputChain, drawWaveforms } from './audio-output.js';
+import state from './state/audioState.js';
 
 let audioFilePausedAt = 0;
 let audioFileStartedAt = 0;
 
 export async function playAudioFile(buffer, seekOffset = 0) {
   stopPlayback();
-  window.audioFileMode = true;
+  state.audioFileMode = true;
 
-  window.audioCtx = new (window.AudioContext || window.webkitAudioContext)();
-  if (window.audioCtx.state === 'suspended') {
-    await window.audioCtx.resume();
+  state.audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+  if (state.audioCtx.state === 'suspended') {
+    await state.audioCtx.resume();
   }
-  window.isPlaying = true;
+  state.isPlaying = true;
 
-  const audioCtx = window.audioCtx;
+  const audioCtx = state.audioCtx;
 
   // デコード
-  if (!window.audioFileBuffer) {
-    window.audioFileBuffer = await audioCtx.decodeAudioData(buffer.slice(0));
+  if (!state.audioFileBuffer) {
+    state.audioFileBuffer = await audioCtx.decodeAudioData(buffer.slice(0));
   }
 
-  const totalDuration = window.audioFileBuffer.duration;
-  window.currentTotalDuration = totalDuration;
+  const totalDuration = state.audioFileBuffer.duration;
+  state.currentTotalDuration = totalDuration;
 
   // === Master層 ===
   const { masterGain, eqOut } = buildMasterChain(audioCtx);
@@ -40,18 +41,18 @@ export async function playAudioFile(buffer, seekOffset = 0) {
   buildOutputChain(audioCtx, eqOut);
 
   // === Source: AudioBufferSourceNode ===
-  window.audioFileSource = audioCtx.createBufferSource();
-  window.audioFileSource.buffer = window.audioFileBuffer;
-  window.audioFileSource.connect(masterGain);
-  window.audioFileSource.start(0, seekOffset);
+  state.audioFileSource = audioCtx.createBufferSource();
+  state.audioFileSource.buffer = state.audioFileBuffer;
+  state.audioFileSource.connect(masterGain);
+  state.audioFileSource.start(0, seekOffset);
   audioFileStartedAt = audioCtx.currentTime - seekOffset;
   audioFilePausedAt = 0;
 
   // 再生終了時
-  window.audioFileSource.onended = () => {
-    if (window.isPlaying && !window.isPaused) {
-      if (window.repeatEnabled) {
-        window.audioFileSource = null;
+  state.audioFileSource.onended = () => {
+    if (state.isPlaying && !state.isPaused) {
+      if (state.repeatEnabled) {
+        state.audioFileSource = null;
         playAudioFile(buffer, 0);
       } else {
         stopPlayback();
@@ -76,27 +77,27 @@ export async function playAudioFile(buffer, seekOffset = 0) {
 
   // 位置表示
   const posDisplay = document.getElementById('position-display');
-  window.playbackStartReal = performance.now();
-  window.playbackStartOffset = seekOffset;
-  window.pauseDuration = 0;
+  state.playbackStartReal = performance.now();
+  state.playbackStartOffset = seekOffset;
+  state.pauseDuration = 0;
 
-  window._audioFileAnimTimer = setInterval(() => {
-    const elapsed = (performance.now() - window.playbackStartReal - window.pauseDuration) / 1000 + seekOffset;
+  state._audioFileAnimTimer = setInterval(() => {
+    const elapsed = (performance.now() - state.playbackStartReal - state.pauseDuration) / 1000 + seekOffset;
     posDisplay.textContent = `${elapsed.toFixed(1)}s / ${totalDuration.toFixed(1)}s`;
     if (typeof window.updatePlayhead === 'function') window.updatePlayhead(elapsed);
   }, 100);
 }
 
 export function pauseAudioFile() {
-  if (!window.isPlaying || !window.audioCtx || window.isPaused || !window.audioFileMode) return;
-  window.isPaused = true;
-  audioFilePausedAt = window.audioCtx.currentTime - audioFileStartedAt;
-  window.audioCtx.suspend();
-  window.pauseStartTime = performance.now();
+  if (!state.isPlaying || !state.audioCtx || state.isPaused || !state.audioFileMode) return;
+  state.isPaused = true;
+  audioFilePausedAt = state.audioCtx.currentTime - audioFileStartedAt;
+  state.audioCtx.suspend();
+  state.pauseStartTime = performance.now();
 
-  if (window._audioFileAnimTimer) {
-    clearInterval(window._audioFileAnimTimer);
-    window._audioFileAnimTimer = null;
+  if (state._audioFileAnimTimer) {
+    clearInterval(state._audioFileAnimTimer);
+    state._audioFileAnimTimer = null;
   }
 
   const btnPlay = document.getElementById('btn-play');
@@ -106,16 +107,16 @@ export function pauseAudioFile() {
 }
 
 export function resumeAudioFile() {
-  if (!window.isPlaying || !window.audioCtx || !window.isPaused || !window.audioFileMode) return;
-  window.isPaused = false;
-  window.pauseDuration += performance.now() - window.pauseStartTime;
-  window.audioCtx.resume();
+  if (!state.isPlaying || !state.audioCtx || !state.isPaused || !state.audioFileMode) return;
+  state.isPaused = false;
+  state.pauseDuration += performance.now() - state.pauseStartTime;
+  state.audioCtx.resume();
 
   const posDisplay = document.getElementById('position-display');
-  window._audioFileAnimTimer = setInterval(() => {
+  state._audioFileAnimTimer = setInterval(() => {
     const elapsed =
-      (performance.now() - window.playbackStartReal - window.pauseDuration) / 1000 + window.playbackStartOffset;
-    posDisplay.textContent = `${elapsed.toFixed(1)}s / ${window.currentTotalDuration.toFixed(1)}s`;
+      (performance.now() - state.playbackStartReal - state.pauseDuration) / 1000 + state.playbackStartOffset;
+    posDisplay.textContent = `${elapsed.toFixed(1)}s / ${state.currentTotalDuration.toFixed(1)}s`;
     if (typeof window.updatePlayhead === 'function') window.updatePlayhead(elapsed);
   }, 100);
 

--- a/js/audio-master.js
+++ b/js/audio-master.js
@@ -2,6 +2,8 @@
 // Master層: MasterGain, HPF/LPF, EQ
 // ============================================================
 
+import state from './state/audioState.js';
+
 // ディストーションカーブ生成
 export function makeDistortionCurve(amount) {
   const samples = 44100;
@@ -37,23 +39,23 @@ export function buildMasterChain(audioCtx) {
   const masterSlider = document.getElementById('master-volume');
   const mVol = masterSlider ? masterSlider.value / 100 : 1.0;
   masterGain.gain.value = mVol;
-  window._masterGain = masterGain;
-  window._audioCtxSampleRate = audioCtx.sampleRate;
+  state._masterGain = masterGain;
+  state._audioCtxSampleRate = audioCtx.sampleRate;
 
   // HPF / LPF (常時接続、XYパッドで操作)
   const hpf = audioCtx.createBiquadFilter();
   hpf.type = 'highpass';
-  hpf.frequency.value = window._hpfFreq || 20;
+  hpf.frequency.value = state._hpfFreq || 20;
   const hpfQSlider = document.getElementById('hpf-q');
   hpf.Q.value = hpfQSlider ? Number(hpfQSlider.value) : 10;
-  window._hpf = hpf;
+  state._hpf = hpf;
 
   const lpf = audioCtx.createBiquadFilter();
   lpf.type = 'lowpass';
-  lpf.frequency.value = window._lpfFreq || 20000;
+  lpf.frequency.value = state._lpfFreq || 20000;
   const lpfQSlider = document.getElementById('lpf-q');
   lpf.Q.value = lpfQSlider ? Number(lpfQSlider.value) : 10;
-  window._lpf = lpf;
+  state._lpf = lpf;
 
   // EQ フィルターチェーン
   const eqBands = document.querySelectorAll('.eq-band');
@@ -67,34 +69,34 @@ export function buildMasterChain(audioCtx) {
     if (filter.type === 'peaking') filter.Q.value = 1.4;
     eqFilters.push(filter);
   });
-  window._eqFilters = eqFilters;
+  state._eqFilters = eqFilters;
 
   // 追加フィルター（モード切替で動的に挿入/取り外し）
   const bandpass = audioCtx.createBiquadFilter();
   bandpass.type = 'bandpass';
-  bandpass.frequency.value = window._bpFreq || 1000;
-  bandpass.Q.value = window._bpQ || 1;
-  window._bandpass = bandpass;
+  bandpass.frequency.value = state._bpFreq || 1000;
+  bandpass.Q.value = state._bpQ || 1;
+  state._bandpass = bandpass;
 
   const notch = audioCtx.createBiquadFilter();
   notch.type = 'notch';
-  notch.frequency.value = window._notchFreq || 1000;
-  notch.Q.value = window._notchQ || 1;
-  window._notch = notch;
+  notch.frequency.value = state._notchFreq || 1000;
+  notch.Q.value = state._notchQ || 1;
+  state._notch = notch;
 
   const peaking = audioCtx.createBiquadFilter();
   peaking.type = 'peaking';
-  peaking.frequency.value = window._peakFreq || 1000;
-  peaking.Q.value = window._peakQ || 1;
-  peaking.gain.value = window._peakGain || 0;
-  window._peaking = peaking;
+  peaking.frequency.value = state._peakFreq || 1000;
+  peaking.Q.value = state._peakQ || 1;
+  peaking.gain.value = state._peakGain || 0;
+  state._peaking = peaking;
 
   // EQチェーンの先頭ノードを取得
   const eqHead = eqFilters.length > 0 ? eqFilters[0] : null;
 
   // フィルターモード切替: LPF → [activeFilter | direct] → EQ先頭
   // デフォルトは HPF/LPF モード（追加フィルターなし）
-  window._switchFilterChain = (mode) => {
+  state._switchFilterChain = (mode) => {
     // 既存接続を切断
     lpf.disconnect();
     bandpass.disconnect();
@@ -150,8 +152,8 @@ export function buildMasterChain(audioCtx) {
   reverbDry.connect(reverbMerge);
   reverbWet.connect(reverbMerge);
 
-  window._masterReverbWet = reverbWet;
-  window._masterReverbConvolver = reverbConvolver;
+  state._masterReverbWet = reverbWet;
+  state._masterReverbConvolver = reverbConvolver;
   prevNode = reverbMerge;
 
   // === マスターコーラス ===
@@ -184,9 +186,9 @@ export function buildMasterChain(audioCtx) {
   chorusDry.connect(chorusMerge);
   chorusWet.connect(chorusMerge);
 
-  window._masterChorusWet = chorusWet;
-  window._masterChorusLfo = chorusLfo;
-  window._masterChorusLfoGain = chorusLfoGain;
+  state._masterChorusWet = chorusWet;
+  state._masterChorusLfo = chorusLfo;
+  state._masterChorusLfoGain = chorusLfoGain;
   prevNode = chorusMerge;
 
   // リミッター (DynamicsCompressorNode) — 常時チェーンに挿入
@@ -195,10 +197,10 @@ export function buildMasterChain(audioCtx) {
   limiter.release.value = 0.05;
   applyLimiterParams(limiter);
   prevNode.connect(limiter);
-  window._limiter = limiter;
+  state._limiter = limiter;
 
   // 現在のフィルターモードを適用（再生開始時にチェーンが再構築されるため）
-  window._switchFilterChain(window._filterMode || 'hpf-lpf');
+  state._switchFilterChain(state._filterMode || 'hpf-lpf');
 
   return { masterGain, eqOut: limiter };
 }
@@ -221,5 +223,5 @@ export function applyLimiterParams(limiter) {
     limiter.knee.value = 0;
     limiter.ratio.value = 1;
   }
-  window._limiterBypassed = !isOn;
+  state._limiterBypassed = !isOn;
 }

--- a/js/audio-output.js
+++ b/js/audio-output.js
@@ -3,6 +3,7 @@
 // ============================================================
 
 import { getThemeColor } from './globals.js';
+import state from './state/audioState.js';
 import { getChannelColor } from './visualizer.js';
 
 // Output分岐構築: eqOut → spectrumAnalyser (表示用)
@@ -12,12 +13,12 @@ export function buildOutputChain(audioCtx, eqOut) {
   const spectrumAnalyser = audioCtx.createAnalyser();
   spectrumAnalyser.fftSize = 4096;
   spectrumAnalyser.smoothingTimeConstant = 0.8;
-  window._spectrumAnalyser = spectrumAnalyser;
+  state._spectrumAnalyser = spectrumAnalyser;
 
   // マスター波形用Analyser → 音声出力
   const masterAnalyser = audioCtx.createAnalyser();
   masterAnalyser.fftSize = 2048;
-  window._masterAnalyser = masterAnalyser;
+  state._masterAnalyser = masterAnalyser;
 
   eqOut.connect(spectrumAnalyser);
   eqOut.connect(masterAnalyser);
@@ -33,14 +34,14 @@ let waveFrameCount = 0;
 
 // 波形描画ループ（30fpsに間引き）
 export function drawWaveforms() {
-  if (!window.isPlaying) {
+  if (!state.isPlaying) {
     // マスタークリア
     const mc = document.getElementById('waveform-master');
     if (mc) {
       const mctx = mc.getContext('2d');
       mctx.clearRect(0, 0, mc.width, mc.height);
     }
-    for (const ch of window.currentChannels) {
+    for (const ch of state.currentChannels) {
       const canvas = document.getElementById(`waveform-${ch}`);
       if (canvas) {
         const ctx = canvas.getContext('2d');
@@ -56,11 +57,11 @@ export function drawWaveforms() {
   if (waveFrameCount % 2 !== 0) return;
 
   // マスター合成波描画
-  if (window._masterAnalyser) {
+  if (state._masterAnalyser) {
     const mc = document.getElementById('waveform-master');
     if (mc) {
       const mctx = mc.getContext('2d');
-      const ma = window._masterAnalyser;
+      const ma = state._masterAnalyser;
       const bufLen = ma.frequencyBinCount;
       if (!waveformMasterBuf || waveformMasterBuf.length !== bufLen) {
         waveformMasterBuf = new Uint8Array(bufLen);
@@ -85,18 +86,18 @@ export function drawWaveforms() {
     }
   }
 
-  for (const ch of window.currentChannels) {
-    const state = window.channelStates[ch];
-    if (!state.analyser) continue;
+  for (const ch of state.currentChannels) {
+    const chState = state.channelStates[ch];
+    if (!chState.analyser) continue;
 
     // ミュート中 or ソロ外のチャンネルはスキップ
-    if (state.playGate === 0) continue;
+    if (chState.playGate === 0) continue;
 
     const canvas = document.getElementById(`waveform-${ch}`);
     if (!canvas) continue;
 
     const ctx = canvas.getContext('2d');
-    const analyser = state.analyser;
+    const analyser = chState.analyser;
     const bufferLength = analyser.frequencyBinCount;
 
     if (!waveformChBufs[ch] || waveformChBufs[ch].length !== bufferLength) {

--- a/js/audio-source.js
+++ b/js/audio-source.js
@@ -2,6 +2,8 @@
 // Source層: メトロノーム生成
 // ============================================================
 
+import state from './state/audioState.js';
+
 export function buildMetronome(audioCtx, destination) {
   const metronomeGain = audioCtx.createGain();
   const metroVolSlider = document.getElementById('metronome-vol');
@@ -11,7 +13,7 @@ export function buildMetronome(audioCtx, destination) {
       : 0.5
     : 0;
   metronomeGain.connect(destination);
-  window._metronomeGain = metronomeGain;
+  state._metronomeGain = metronomeGain;
   return metronomeGain;
 }
 

--- a/js/dj-controls.js
+++ b/js/dj-controls.js
@@ -3,26 +3,25 @@
 // ============================================================
 
 import { playNotesFrom, stopPlayback } from './audio-engine.js';
+import state from './state/audioState.js';
 
 // --- Hot Cue ---
 const hotCues = [null, null, null, null, null, null, null, null];
 
 function getCurrentPlaybackTime() {
-  if (!window.isPlaying || !window.playbackStartReal) return 0;
-  const pause = window.isPaused
-    ? performance.now() - window.pauseStartTime + window.pauseDuration
-    : window.pauseDuration;
-  return (performance.now() - window.playbackStartReal - pause) / 1000 + window.playbackStartOffset;
+  if (!state.isPlaying || !state.playbackStartReal) return 0;
+  const pause = state.isPaused ? performance.now() - state.pauseStartTime + state.pauseDuration : state.pauseDuration;
+  return (performance.now() - state.playbackStartReal - pause) / 1000 + state.playbackStartOffset;
 }
 
 document.getElementById('hot-cue-pads').addEventListener('click', (e) => {
   const pad = e.target.closest('.hot-cue-pad');
-  if (!pad || !window.currentNotes.length) return;
+  if (!pad || !state.currentNotes.length) return;
   const slot = Number(pad.dataset.slot);
 
   if (hotCues[slot] === null) {
     // Set cue at current position
-    const time = window.isPlaying ? getCurrentPlaybackTime() : 0;
+    const time = state.isPlaying ? getCurrentPlaybackTime() : 0;
     hotCues[slot] = time;
     pad.classList.add('set');
     pad.title = `${time.toFixed(1)}s`;
@@ -30,7 +29,7 @@ document.getElementById('hot-cue-pads').addEventListener('click', (e) => {
     // Jump to cue（ABループは解除）
     clearABLoop();
     stopPlayback();
-    playNotesFrom(window.currentNotes, window.currentBpm, hotCues[slot]);
+    playNotesFrom(state.currentNotes, state.currentBpm, hotCues[slot]);
   }
 });
 
@@ -56,16 +55,16 @@ const btnLoopClear = document.getElementById('btn-loop-clear');
 const abLoopInfo = document.getElementById('ab-loop-info');
 
 btnLoopA.addEventListener('click', () => {
-  if (!window.currentNotes.length) return;
-  loopA = window.isPlaying ? getCurrentPlaybackTime() : 0;
+  if (!state.currentNotes.length) return;
+  loopA = state.isPlaying ? getCurrentPlaybackTime() : 0;
   btnLoopA.classList.add('active');
   btnLoopB.disabled = false;
   abLoopInfo.textContent = `A: ${loopA.toFixed(1)}s`;
 });
 
 btnLoopB.addEventListener('click', () => {
-  if (loopA === null || !window.currentNotes.length) return;
-  loopB = window.isPlaying ? getCurrentPlaybackTime() : window.currentTotalDuration;
+  if (loopA === null || !state.currentNotes.length) return;
+  loopB = state.isPlaying ? getCurrentPlaybackTime() : state.currentTotalDuration;
   if (loopB <= loopA) return;
   btnLoopB.classList.add('active');
   abLoopInfo.textContent = `A: ${loopA.toFixed(1)}s → B: ${loopB.toFixed(1)}s`;
@@ -78,7 +77,7 @@ function startABLoop() {
   clearLoopTimer();
   // Jump to A point
   stopPlayback();
-  playNotesFrom(window.currentNotes, window.currentBpm, loopA);
+  playNotesFrom(state.currentNotes, state.currentBpm, loopA);
 
   // Schedule loop back to A when reaching B
   const loopDuration = loopB - loopA;
@@ -109,19 +108,19 @@ export function clearLoopTimer() {
 // --- Beat Jump ---
 document.getElementById('beat-jump-controls').addEventListener('click', (e) => {
   const btn = e.target.closest('.beat-jump-btn');
-  if (!btn || !window.isPlaying || !window.currentNotes.length) return;
+  if (!btn || !state.isPlaying || !state.currentNotes.length) return;
   const beats = Number(btn.dataset.beats);
-  const beatDuration = 60 / window.currentBpm;
+  const beatDuration = 60 / state.currentBpm;
   const jumpTime = beats * beatDuration;
   const current = getCurrentPlaybackTime();
-  const target = Math.max(0, Math.min(current + jumpTime, window.currentTotalDuration));
+  const target = Math.max(0, Math.min(current + jumpTime, state.currentTotalDuration));
   stopPlayback();
-  playNotesFrom(window.currentNotes, window.currentBpm, target);
+  playNotesFrom(state.currentNotes, state.currentBpm, target);
 });
 
 // --- Piano Roll Markers ---
 export function drawDJMarkers(ctx, W, H, paddingLeft = 0) {
-  const dur = window.currentTotalDuration || 1;
+  const dur = state.currentTotalDuration || 1;
   const plotW = W - paddingLeft;
 
   // Hot Cue markers

--- a/js/globals.js
+++ b/js/globals.js
@@ -2,40 +2,24 @@
 // グローバル変数・定数
 // ============================================================
 
-window.currentNotes = [];
-window.currentBpm = 120;
-window.currentTotalDuration = 0;
-window.playbackStartReal = 0;
-window.playbackStartOffset = 0;
-window.channelStates = {};
-window.channelPrograms = {};
-window.currentChannels = [];
-window.repeatEnabled = false;
-// チャンネル別エフェクト状態
-window.channelFxState = {};
-// オーディオエンジン共有状態
-window.audioCtx = null;
-window.isPlaying = false;
-window.isPaused = false;
-window.pauseDuration = 0;
-window.pauseStartTime = 0;
-// オーディオファイルエンジン共有状態
-window.audioFileSource = null;
-window.audioFileBuffer = null;
-window.audioFileMode = false;
-// スケジュール済みノード（波形切替用）
-window.scheduledNodes = [];
+import state from './state/audioState.js';
+
+// window.* ブリッジ（後方互換: main.js や typeof ガード用）
+// state module の値を window に同期
+for (const key of Object.keys(state)) {
+  window[key] = state[key];
+}
 
 export function getChannelFx(ch) {
-  if (!window.channelFxState[ch]) {
-    window.channelFxState[ch] = {
+  if (!state.channelFxState[ch]) {
+    state.channelFxState[ch] = {
       waveType: 'triangle',
       distortion: { enabled: false, amount: 50 },
       delay: { enabled: false, time: 300 },
       reverb: { enabled: false, mix: 40 },
     };
   }
-  return window.channelFxState[ch];
+  return state.channelFxState[ch];
 }
 
 // 対数スケール変換 (スライダー0-100 ↔ 周波数20-20000Hz)

--- a/js/main.js
+++ b/js/main.js
@@ -3,9 +3,6 @@
 // 全モジュールをimportし、公開APIをwindowに代入
 // ============================================================
 
-// biome-ignore assist/source/organizeImports: globals.js は最初に import する必要がある（window.* state 初期化）
-import * as globals from './globals.js';
-
 import * as app from './app.js';
 import * as audioChannel from './audio-channel.js';
 import * as audioEngine from './audio-engine.js';
@@ -14,16 +11,16 @@ import * as audioMaster from './audio-master.js';
 import * as audioOutput from './audio-output.js';
 import * as audioSource from './audio-source.js';
 import * as djControls from './dj-controls.js';
-// 各モジュールから関数・クラス・定数をimport
+import * as globals from './globals.js';
 import * as midiParser from './midi-parser.js';
 import * as pianoRoll from './piano-roll.js';
 import * as playlist from './playlist.js';
 import * as sf2Parser from './sf2-parser.js';
+import state from './state/audioState.js';
 import * as visualizer from './visualizer.js';
 import * as waveforms from './waveforms.js';
 
 // --- 関数・クラス・定数を window に公開 ---
-// state は globals.js で window に直接初期化済みなので、ここでは関数のみ
 const modules = [
   globals,
   midiParser,
@@ -46,4 +43,17 @@ for (const mod of modules) {
   for (const [key, value] of Object.entries(mod)) {
     window[key] = value;
   }
+}
+
+// --- state → window 双方向ブリッジ ---
+// state のプロパティを window に Proxy で同期
+// typeof ガード付き呼び出しや window.AudioContext 等のために必要
+for (const key of Object.keys(state)) {
+  Object.defineProperty(window, key, {
+    get: () => state[key],
+    set: (v) => {
+      state[key] = v;
+    },
+    configurable: true,
+  });
 }

--- a/js/piano-roll.js
+++ b/js/piano-roll.js
@@ -6,6 +6,7 @@ import { playNotesFrom, stopPlayback } from './audio-engine.js';
 import { playAudioFile } from './audio-file-engine.js';
 import { drawDJMarkers } from './dj-controls.js';
 import { getThemeColor } from './globals.js';
+import state from './state/audioState.js';
 import { CHANNEL_COLORS } from './visualizer.js';
 
 const PIANO_PADDING_LEFT = 0;
@@ -21,7 +22,7 @@ function buildPianoRollCache() {
   const W = canvas.clientWidth;
   const H = canvas.clientHeight;
 
-  if (!W || !H || !window.currentNotes.length) {
+  if (!W || !H || !state.currentNotes.length) {
     pianoRollCache = null;
     return;
   }
@@ -33,12 +34,12 @@ function buildPianoRollCache() {
   const ctx = offscreen.getContext('2d');
   ctx.scale(dpr, dpr);
 
-  const dur = window.currentTotalDuration || Math.max(...window.currentNotes.map((n) => n.startTime + n.duration));
+  const dur = state.currentTotalDuration || Math.max(...state.currentNotes.map((n) => n.startTime + n.duration));
 
   // 音域検出（パディング付き）
   let minNote = 127;
   let maxNote = 0;
-  for (const n of window.currentNotes) {
+  for (const n of state.currentNotes) {
     if (n.note < minNote) minNote = n.note;
     if (n.note > maxNote) maxNote = n.note;
   }
@@ -47,10 +48,10 @@ function buildPianoRollCache() {
   const noteRange = maxNote - minNote + 1;
 
   // ノート描画
-  for (const n of window.currentNotes) {
-    const isMuted = window.channelStates[n.channel]?.muted;
-    const anySolo = Object.values(window.channelStates).some((s) => s.soloed);
-    const isSoloed = window.channelStates[n.channel]?.soloed;
+  for (const n of state.currentNotes) {
+    const isMuted = state.channelStates[n.channel]?.muted;
+    const anySolo = Object.values(state.channelStates).some((s) => s.soloed);
+    const isSoloed = state.channelStates[n.channel]?.soloed;
     const hidden = anySolo ? !isSoloed : isMuted;
 
     const x = (n.startTime / dur) * W;
@@ -96,7 +97,7 @@ export function drawPianoRoll() {
   ctx.scale(dpr, dpr);
 
   ctx.clearRect(0, 0, W, H);
-  if (!window.currentNotes.length) return;
+  if (!state.currentNotes.length) return;
 
   // キャッシュがなければ構築
   if (!pianoRollCache || pianoRollCacheW !== W || pianoRollCacheH !== H) {
@@ -116,7 +117,7 @@ export function drawPianoRoll() {
 
 // ピアノロールクリックでシーク
 document.getElementById('piano-roll-canvas').addEventListener('click', (e) => {
-  if (!window.currentNotes.length && !window.audioFileMode) return;
+  if (!state.currentNotes.length && !state.audioFileMode) return;
   const canvas = e.target;
   const rect = canvas.getBoundingClientRect();
   const x = e.clientX - rect.left;
@@ -124,12 +125,12 @@ document.getElementById('piano-roll-canvas').addEventListener('click', (e) => {
   const plotW = canvas.clientWidth - PADDING_LEFT;
   const ratio = (x - PADDING_LEFT) / plotW;
   if (ratio < 0 || ratio > 1) return;
-  const seekTime = ratio * (window.currentTotalDuration || 1);
+  const seekTime = ratio * (state.currentTotalDuration || 1);
   stopPlayback();
-  if (window.audioFileMode) {
-    playAudioFile(window._audioFileRawBuffer, seekTime);
+  if (state.audioFileMode) {
+    playAudioFile(state._audioFileRawBuffer, seekTime);
   } else {
-    playNotesFrom(window.currentNotes, window.currentBpm, seekTime);
+    playNotesFrom(state.currentNotes, state.currentBpm, seekTime);
   }
 });
 
@@ -149,7 +150,7 @@ export function updatePlayhead(elapsed) {
   const H = prCanvas.clientHeight;
   const PADDING_LEFT = PIANO_PADDING_LEFT;
   const plotW = W - PADDING_LEFT;
-  const dur = window.currentTotalDuration || 1;
+  const dur = state.currentTotalDuration || 1;
   const x = PADDING_LEFT + (elapsed / dur) * plotW;
 
   // Playhead

--- a/js/playlist.js
+++ b/js/playlist.js
@@ -4,6 +4,7 @@
 
 import { playNotes } from './audio-engine.js';
 import { playAudioFile } from './audio-file-engine.js';
+import state from './state/audioState.js';
 
 const SUPPORTED_EXTENSIONS = ['.mid', '.midi', '.wav', '.mp3', '.ogg', '.flac', '.aac', '.m4a', '.webm'];
 
@@ -69,10 +70,10 @@ export async function playNextTrack() {
   const next = playlist.currentIndex + 1;
   if (next < playlist.tracks.length) {
     await selectTrack(next);
-    if (window.audioFileMode) {
-      playAudioFile(window._audioFileRawBuffer);
+    if (state.audioFileMode) {
+      playAudioFile(state._audioFileRawBuffer);
     } else {
-      playNotes(window.currentNotes, window.currentBpm);
+      playNotes(state.currentNotes, state.currentBpm);
     }
   }
 }
@@ -81,10 +82,10 @@ export async function playPrevTrack() {
   const prev = playlist.currentIndex - 1;
   if (prev >= 0) {
     await selectTrack(prev);
-    if (window.audioFileMode) {
-      playAudioFile(window._audioFileRawBuffer);
+    if (state.audioFileMode) {
+      playAudioFile(state._audioFileRawBuffer);
     } else {
-      playNotes(window.currentNotes, window.currentBpm);
+      playNotes(state.currentNotes, state.currentBpm);
     }
   }
 }
@@ -112,10 +113,10 @@ function renderPlaylist() {
     }
     li.addEventListener('click', async () => {
       await selectTrack(i);
-      if (window.audioFileMode) {
-        playAudioFile(window._audioFileRawBuffer);
-      } else if (window.currentNotes.length > 0) {
-        playNotes(window.currentNotes, window.currentBpm);
+      if (state.audioFileMode) {
+        playAudioFile(state._audioFileRawBuffer);
+      } else if (state.currentNotes.length > 0) {
+        playNotes(state.currentNotes, state.currentBpm);
       }
     });
     ul.appendChild(li);

--- a/js/state/audioState.js
+++ b/js/state/audioState.js
@@ -1,0 +1,82 @@
+// ============================================================
+// 共有オーディオ状態
+// 全モジュールからimportして使用する一元管理モジュール
+// ============================================================
+
+const audioState = {
+  // --- 再生状態 ---
+  audioCtx: null,
+  isPlaying: false,
+  isPaused: false,
+  pauseDuration: 0,
+  pauseStartTime: 0,
+
+  // --- MIDI データ ---
+  currentNotes: [],
+  currentBpm: 120,
+  currentTotalDuration: 0,
+  playbackStartReal: 0,
+  playbackStartOffset: 0,
+  channelStates: {},
+  channelPrograms: {},
+  currentChannels: [],
+  repeatEnabled: false,
+
+  // --- チャンネルFX ---
+  channelFxState: {},
+  scheduledNodes: [],
+
+  // --- オーディオファイル ---
+  audioFileSource: null,
+  audioFileBuffer: null,
+  audioFileMode: false,
+
+  // --- オーディオノード参照 ---
+  _masterGain: null,
+  _hpf: null,
+  _lpf: null,
+  _bandpass: null,
+  _notch: null,
+  _peaking: null,
+  _eqFilters: null,
+  _limiter: null,
+  _limiterBypassed: false,
+  _spectrumAnalyser: null,
+  _masterAnalyser: null,
+  _metronomeGain: null,
+  _masterReverbConvolver: null,
+  _masterReverbWet: null,
+  _masterChorusLfo: null,
+  _masterChorusLfoGain: null,
+  _masterChorusWet: null,
+  _switchFilterChain: null,
+
+  // --- フィルターパラメータ ---
+  _filterMode: 'direct',
+  _hpfFreq: 20,
+  _lpfFreq: 20000,
+  _bpFreq: 1000,
+  _bpQ: 1,
+  _notchFreq: 1000,
+  _notchQ: 1,
+  _peakFreq: 1000,
+  _peakGain: 0,
+  _peakQ: 1,
+
+  // --- ピッチ/周波数/スケール ---
+  _pitchShift: 0,
+  _freqShift: 0,
+  _scaleConvert: { enabled: false, key: 0, from: 'major', to: 'minor' },
+
+  // --- SF2 ---
+  _sf: null,
+  _useSF: false,
+  _sf2PresetMap: null,
+
+  // --- オーディオファイル再生 ---
+  _audioFileRawBuffer: null,
+  _audioCtxSampleRate: 44100,
+  _audioFileAnimTimer: null,
+};
+
+export default audioState;

--- a/js/visualizer.js
+++ b/js/visualizer.js
@@ -5,6 +5,7 @@
 import { getChannelFx, getThemeColor } from './globals.js';
 import { getInstrumentName } from './midi-parser.js';
 import { invalidatePianoRollCache } from './piano-roll.js';
+import state from './state/audioState.js';
 
 const CHANNEL_COLORS = [
   '#b39ddb', // パステル紫
@@ -30,7 +31,7 @@ export { CHANNEL_COLORS };
 function getChannelLabel(ch) {
   const num = ch + 1;
   if (num === 10) return 'Ch.10 (Drums)';
-  const program = window.channelPrograms[ch];
+  const program = state.channelPrograms[ch];
   if (program !== undefined) {
     return `Ch.${num} - ${getInstrumentName(program)}`;
   }
@@ -50,7 +51,7 @@ export function detectChannels(notes) {
 export function buildChannelUI(channels) {
   const container = document.getElementById('visualizer-container');
   container.innerHTML = '';
-  window.channelStates = {};
+  state.channelStates = {};
 
   // マスター合成波カード（4列幅）
   const masterCard = document.createElement('div');
@@ -77,7 +78,7 @@ export function buildChannelUI(channels) {
 
   for (const ch of allChannels) {
     const isActive = channels.includes(ch);
-    window.channelStates[ch] = {
+    state.channelStates[ch] = {
       muted: !isActive,
       soloed: false,
       gainNode: null,
@@ -297,37 +298,37 @@ function drawCables(allChannels) {
 }
 
 export function toggleMute(ch) {
-  const state = window.channelStates[ch];
-  state.muted = !state.muted;
+  const chState = state.channelStates[ch];
+  chState.muted = !chState.muted;
   const btn = document.querySelector(`#channel-card-${ch} .btn-mute`);
-  btn.classList.toggle('active', state.muted);
+  btn.classList.toggle('active', chState.muted);
   updateChannelGains();
   if (typeof invalidatePianoRollCache === 'function') invalidatePianoRollCache();
 }
 
 export function toggleSolo(ch) {
-  const state = window.channelStates[ch];
-  state.soloed = !state.soloed;
+  const chState = state.channelStates[ch];
+  chState.soloed = !chState.soloed;
   const btn = document.querySelector(`#channel-card-${ch} .btn-solo`);
-  btn.classList.toggle('active', state.soloed);
+  btn.classList.toggle('active', chState.soloed);
   updateChannelGains();
   if (typeof invalidatePianoRollCache === 'function') invalidatePianoRollCache();
 }
 
 export function updateChannelGains() {
-  const anySolo = Object.values(window.channelStates).some((s) => s.soloed);
-  for (const [ch, state] of Object.entries(window.channelStates)) {
-    if (!state.gainNode) continue;
-    const shouldPlay = anySolo ? state.soloed && !state.muted : !state.muted;
-    state.playGate = shouldPlay ? 1 : 0;
-    applyChannelGain(state);
+  const anySolo = Object.values(state.channelStates).some((s) => s.soloed);
+  for (const [ch, chState] of Object.entries(state.channelStates)) {
+    if (!chState.gainNode) continue;
+    const shouldPlay = anySolo ? chState.soloed && !chState.muted : !chState.muted;
+    chState.playGate = shouldPlay ? 1 : 0;
+    applyChannelGain(chState);
   }
 }
 
 // waveGain × playGate を gainNode に適用
-export function applyChannelGain(state) {
-  if (!state.gainNode) return;
-  const waveGain = state.waveGain ?? 1;
-  const playGate = state.playGate ?? 1;
-  state.gainNode.gain.value = waveGain * playGate;
+export function applyChannelGain(chState) {
+  if (!chState.gainNode) return;
+  const waveGain = chState.waveGain ?? 1;
+  const playGate = chState.playGate ?? 1;
+  chState.gainNode.gain.value = waveGain * playGate;
 }


### PR DESCRIPTION
## What
- `js/state/audioState.js` を新規作成（共有mutable stateの一元管理モジュール）
- 全ファイルの `window.*` state参照を `state.*` に置き換え（`import state from './state/audioState.js'`）
- `globals.js` の初期化を `audioState` ベースに変更
- `main.js` に `state → window` 双方向ブリッジ（`Object.defineProperty`）を追加
- ローカル変数名の衝突を解消（`const state → const chState`）

## Why
Phase 2の state module 移行。`window.*` にばらまかれていた共有stateを1つのモジュールに集約し、依存関係を明示化する。循環依存回避のための `typeof window.xxx` ガードは維持。

## Risk
- low（E2E 57件全パス、window ブリッジで後方互換維持）

### 残存する window.* 参照
- `window.AudioContext` / `window.devicePixelRatio` — ブラウザAPI
- 循環依存回避の `typeof window.xxx === 'function'` ガード（startSpectrumDraw, playNextTrack 等）
- `playlist.js` → app.js 関数（isAudioFile, processAudioFile, processMidi）