### PR TITLE
test: engine系統合テスト実装（26テスト追加、合計203）

### DIFF
--- a/docs/plans/test-strategy.md
+++ b/docs/plans/test-strategy.md
@@ -118,20 +118,20 @@
 
 | 関数 | テスト種別 | ステータス | 理由 |
 |------|-----------|----------|------|
-| `applyFreqShiftToActive()` | 統合 | ⬜ 未着手 | scheduledNodes操作 |
-| `playNotes(notes, bpm, seekOffset)` | 統合 | ⬜ 未着手 | 再生オーケストレーション全体 |
-| `pausePlayback()` | 統合 | ⬜ 未着手 | AudioContext.suspend |
-| `resumePlayback()` | 統合 | ⬜ 未着手 | AudioContext.resume |
-| `stopPlayback()` | 統合 | ⬜ 未着手 | 全ノード停止・クリーンアップ |
-| `playNotesFrom(notes, bpm, fromTime)` | 統合 | ⬜ 未着手 | シーク再生 |
+| `applyFreqShiftToActive()` | 統合 | ✅ 完了 | scheduledNodes操作 |
+| `playNotes(notes, bpm, seekOffset)` | 統合 | ⚠️ E2Eカバー（オーケストレーション全体のため統合テスト対象外） | 再生オーケストレーション全体 |
+| `pausePlayback()` | 統合 | ✅ 完了 | AudioContext.suspend |
+| `resumePlayback()` | 統合 | ✅ 完了 | AudioContext.resume |
+| `stopPlayback()` | 統合 | ✅ 完了 | 全ノード停止・クリーンアップ |
+| `playNotesFrom(notes, bpm, fromTime)` | 統合 | ⚠️ E2Eカバー（playNotesのラッパーのため統合テスト対象外） | シーク再生 |
 
 ### audio-file-engine.js
 
 | 関数 | テスト種別 | ステータス | 理由 |
 |------|-----------|----------|------|
-| `playAudioFile(buffer, seekOffset)` | 統合 | ⬜ 未着手 | AudioBufferSourceNode再生 |
-| `pauseAudioFile()` | 統合 | ⬜ 未着手 | suspend |
-| `resumeAudioFile()` | 統合 | ⬜ 未着手 | resume + シーク再開 |
+| `playAudioFile(buffer, seekOffset)` | 統合 | ⚠️ E2Eカバー（オーケストレーション全体のため統合テスト対象外） | AudioBufferSourceNode再生 |
+| `pauseAudioFile()` | 統合 | ✅ 完了 | suspend |
+| `resumeAudioFile()` | 統合 | ✅ 完了 | resume + シーク再開 |
 
 ### visualizer.js
 
@@ -142,7 +142,7 @@
 | `buildChannelUI(channels)` | E2E | ✅ E2Eカバー済み | DOM生成 |
 | `toggleMute(ch)` | E2E | ✅ E2Eカバー済み | DOM操作 + state変更 |
 | `toggleSolo(ch)` | E2E | ✅ E2Eカバー済み | DOM操作 + state変更 |
-| `updateChannelGains()` | 統合 | ⬜ 未着手 | GainNode操作（ロジックはテスト可能） |
+| `updateChannelGains()` | 統合 | ✅ 完了 | GainNode操作（ロジックはテスト可能） |
 | `applyChannelGain(chState)` | ユニット | ✅ 完了 | waveGain × playGate 計算（GainNode設定） |
 
 ### piano-roll.js

--- a/tests/integration/audio-engine.test.js
+++ b/tests/integration/audio-engine.test.js
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { applyFreqShiftToActive, pausePlayback, resumePlayback, stopPlayback } from '../../js/audio-engine.js';
+import state from '../../js/state/audioState.js';
+import { createMockAudioContext } from './web-audio-mock.js';
+
+// lucide グローバルモック（DOM操作で呼ばれる）
+globalThis.lucide = { createIcons: vi.fn() };
+
+// ============================================================
+// applyFreqShiftToActive()
+// ============================================================
+
+describe('applyFreqShiftToActive()', () => {
+  beforeEach(() => {
+    state.scheduledNodes = [];
+    window._pitchShift = 0;
+    window._freqShift = 0;
+    window._scaleConvert = null;
+  });
+
+  it('空のscheduledNodesでエラーにならない', () => {
+    expect(() => applyFreqShiftToActive()).not.toThrow();
+  });
+
+  it('オシレーターノードのfrequencyを更新する', () => {
+    const osc = {
+      _baseMidi: 69, // A4
+      frequency: { value: 0 },
+    };
+    state.scheduledNodes = [osc];
+    applyFreqShiftToActive();
+    expect(osc.frequency.value).toBeCloseTo(440, 0);
+  });
+
+  it('SF2ノードのplaybackRateを更新する', () => {
+    const node = {
+      _baseMidi: 60,
+      _isSF2: true,
+      _rootKey: 60,
+      _sampleTuning: 0,
+      playbackRate: { value: 1 },
+    };
+    state.scheduledNodes = [node];
+    applyFreqShiftToActive();
+    // rootKey == baseMidi, tuning == 0, pitchShift == 0 → rate = 1
+    expect(node.playbackRate.value).toBeCloseTo(1, 5);
+  });
+
+  it('pitchShiftが反映される（SF2）', () => {
+    state._pitchShift = 12;
+    const node = {
+      _baseMidi: 60,
+      _isSF2: true,
+      _rootKey: 60,
+      _sampleTuning: 0,
+      playbackRate: { value: 1 },
+    };
+    state.scheduledNodes = [node];
+    applyFreqShiftToActive();
+    // +12 semitones → rate = 2
+    expect(node.playbackRate.value).toBeCloseTo(2, 3);
+  });
+
+  it('_baseMidiがないノードはスキップする', () => {
+    const node = { frequency: { value: 100 } };
+    state.scheduledNodes = [node];
+    expect(() => applyFreqShiftToActive()).not.toThrow();
+    expect(node.frequency.value).toBe(100); // 変更されない
+  });
+});
+
+// ============================================================
+// pausePlayback()
+// ============================================================
+
+describe('pausePlayback()', () => {
+  beforeEach(() => {
+    state.isPlaying = false;
+    state.isPaused = false;
+    state.audioCtx = null;
+  });
+
+  it('再生中でなければ何もしない', () => {
+    state.isPlaying = false;
+    expect(() => pausePlayback()).not.toThrow();
+    expect(state.isPaused).toBe(false);
+  });
+
+  it('再生中ならisPausedをtrueにする', () => {
+    const ctx = createMockAudioContext();
+    state.isPlaying = true;
+    state.isPaused = false;
+    state.audioCtx = ctx;
+    pausePlayback();
+    expect(state.isPaused).toBe(true);
+    expect(ctx.suspend).toHaveBeenCalled();
+  });
+
+  it('既にポーズ中なら何もしない', () => {
+    const ctx = createMockAudioContext();
+    state.isPlaying = true;
+    state.isPaused = true;
+    state.audioCtx = ctx;
+    pausePlayback();
+    expect(ctx.suspend).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================
+// resumePlayback()
+// ============================================================
+
+describe('resumePlayback()', () => {
+  beforeEach(() => {
+    state.isPlaying = false;
+    state.isPaused = false;
+    state.audioCtx = null;
+    state.pauseDuration = 0;
+    state.pauseStartTime = 0;
+    state.playbackStartReal = 0;
+    state.playbackStartOffset = 0;
+    state.currentTotalDuration = 10;
+  });
+
+  it('ポーズ中でなければ何もしない', () => {
+    state.isPlaying = true;
+    state.isPaused = false;
+    state.audioCtx = createMockAudioContext();
+    expect(() => resumePlayback()).not.toThrow();
+  });
+
+  it('ポーズ中ならisPausedをfalseにしてresumeする', () => {
+    const ctx = createMockAudioContext();
+    state.isPlaying = true;
+    state.isPaused = true;
+    state.audioCtx = ctx;
+    state.pauseStartTime = performance.now() - 1000;
+    resumePlayback();
+    expect(state.isPaused).toBe(false);
+    expect(ctx.resume).toHaveBeenCalled();
+    expect(state.pauseDuration).toBeGreaterThan(0);
+  });
+});
+
+// ============================================================
+// stopPlayback()
+// ============================================================
+
+describe('stopPlayback()', () => {
+  beforeEach(() => {
+    state.isPlaying = true;
+    state.isPaused = false;
+    state.audioCtx = null;
+    state.scheduledNodes = [];
+    state.audioFileSource = null;
+    state.pauseDuration = 100;
+    state.pauseStartTime = 100;
+  });
+
+  it('isPlayingをfalseにする', () => {
+    stopPlayback();
+    expect(state.isPlaying).toBe(false);
+  });
+
+  it('pause関連stateをリセットする', () => {
+    stopPlayback();
+    expect(state.isPaused).toBe(false);
+    expect(state.pauseDuration).toBe(0);
+    expect(state.pauseStartTime).toBe(0);
+  });
+
+  it('scheduledNodesの全ノードを停止する', () => {
+    const osc1 = { stop: vi.fn() };
+    const osc2 = { stop: vi.fn() };
+    state.scheduledNodes = [osc1, osc2];
+    stopPlayback();
+    expect(osc1.stop).toHaveBeenCalled();
+    expect(osc2.stop).toHaveBeenCalled();
+  });
+
+  it('audioFileSourceを停止する', () => {
+    const source = { stop: vi.fn() };
+    state.audioFileSource = source;
+    stopPlayback();
+    expect(source.stop).toHaveBeenCalled();
+    expect(state.audioFileSource).toBeNull();
+  });
+
+  it('audioCtxがあればcloseする', () => {
+    const ctx = createMockAudioContext();
+    state.audioCtx = ctx;
+    stopPlayback();
+    expect(ctx.close).toHaveBeenCalled();
+  });
+
+  it('再生中でなくてもエラーにならない', () => {
+    state.isPlaying = false;
+    expect(() => stopPlayback()).not.toThrow();
+  });
+});

--- a/tests/integration/audio-file-engine.test.js
+++ b/tests/integration/audio-file-engine.test.js
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { pauseAudioFile, resumeAudioFile } from '../../js/audio-file-engine.js';
+import state from '../../js/state/audioState.js';
+import { createMockAudioContext } from './web-audio-mock.js';
+
+globalThis.lucide = { createIcons: vi.fn() };
+
+describe('pauseAudioFile()', () => {
+  beforeEach(() => {
+    state.isPlaying = false;
+    state.isPaused = false;
+    state.audioCtx = null;
+    state.audioFileMode = false;
+  });
+
+  it('再生中でなければ何もしない', () => {
+    expect(() => pauseAudioFile()).not.toThrow();
+    expect(state.isPaused).toBe(false);
+  });
+
+  it('audioFileModeでなければ何もしない', () => {
+    const ctx = createMockAudioContext();
+    state.isPlaying = true;
+    state.audioCtx = ctx;
+    state.audioFileMode = false;
+    pauseAudioFile();
+    expect(state.isPaused).toBe(false);
+  });
+
+  it('再生中＋audioFileModeならisPausedをtrueにしてsuspendする', () => {
+    const ctx = createMockAudioContext();
+    ctx.currentTime = 5;
+    state.isPlaying = true;
+    state.isPaused = false;
+    state.audioCtx = ctx;
+    state.audioFileMode = true;
+    pauseAudioFile();
+    expect(state.isPaused).toBe(true);
+    expect(ctx.suspend).toHaveBeenCalled();
+  });
+});
+
+describe('resumeAudioFile()', () => {
+  beforeEach(() => {
+    state.isPlaying = false;
+    state.isPaused = false;
+    state.audioCtx = null;
+    state.audioFileMode = false;
+    state.pauseDuration = 0;
+    state.pauseStartTime = 0;
+    state.playbackStartReal = performance.now() - 5000;
+    state.playbackStartOffset = 0;
+    state.currentTotalDuration = 60;
+  });
+
+  it('ポーズ中でなければ何もしない', () => {
+    expect(() => resumeAudioFile()).not.toThrow();
+  });
+
+  it('ポーズ中＋audioFileModeならisPausedをfalseにしてresumeする', () => {
+    const ctx = createMockAudioContext();
+    state.isPlaying = true;
+    state.isPaused = true;
+    state.audioCtx = ctx;
+    state.audioFileMode = true;
+    state.pauseStartTime = performance.now() - 500;
+    resumeAudioFile();
+    expect(state.isPaused).toBe(false);
+    expect(ctx.resume).toHaveBeenCalled();
+  });
+});

--- a/tests/integration/visualizer.test.js
+++ b/tests/integration/visualizer.test.js
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import state from '../../js/state/audioState.js';
+import { updateChannelGains } from '../../js/visualizer.js';
+
+describe('updateChannelGains()', () => {
+  beforeEach(() => {
+    state.channelStates = {
+      0: { gainNode: { gain: { value: 0 } }, waveGain: 0.8, playGate: 1, muted: false, soloed: false },
+      1: { gainNode: { gain: { value: 0 } }, waveGain: 0.6, playGate: 1, muted: false, soloed: false },
+      2: { gainNode: { gain: { value: 0 } }, waveGain: 1.0, playGate: 1, muted: true, soloed: false },
+    };
+  });
+
+  it('ミュートされたチャンネルのplayGateを0にする', () => {
+    updateChannelGains();
+    expect(state.channelStates[2].playGate).toBe(0);
+    expect(state.channelStates[2].gainNode.gain.value).toBe(0);
+  });
+
+  it('ミュートされていないチャンネルのplayGateは1', () => {
+    updateChannelGains();
+    expect(state.channelStates[0].playGate).toBe(1);
+    expect(state.channelStates[0].gainNode.gain.value).toBeCloseTo(0.8, 5);
+  });
+
+  it('ソロ中は他のチャンネルがミュートされる', () => {
+    state.channelStates[0].soloed = true;
+    updateChannelGains();
+    expect(state.channelStates[0].playGate).toBe(1);
+    expect(state.channelStates[1].playGate).toBe(0);
+    expect(state.channelStates[2].playGate).toBe(0); // ミュート+非ソロ
+  });
+
+  it('ソロかつミュートのチャンネルはミュートが優先', () => {
+    state.channelStates[0].soloed = true;
+    state.channelStates[0].muted = true;
+    updateChannelGains();
+    expect(state.channelStates[0].playGate).toBe(0);
+  });
+
+  it('gainNodeがないチャンネルでもエラーにならない', () => {
+    state.channelStates[3] = { muted: false, soloed: false };
+    expect(() => updateChannelGains()).not.toThrow();
+  });
+});

--- a/tests/unit/setup-dom.js
+++ b/tests/unit/setup-dom.js
@@ -93,6 +93,7 @@ const elements = [
   'sf2-input',
   'sf2-name',
   'btn-repeat',
+  'position-display',
   'info-filename',
   'info-format',
   'info-tracks',


### PR DESCRIPTION
## What
- `audio-engine.test.js` 新規追加（16テスト）
  - `applyFreqShiftToActive`: オシレーター/SF2ノードの周波数更新、pitchShift反映（5テスト）
  - `pausePlayback`: 再生中/非再生中/既にポーズ中の分岐（3テスト）
  - `resumePlayback`: ポーズ中/非ポーズ中の分岐、pauseDuration加算（2テスト）
  - `stopPlayback`: state リセット、ノード停止、AudioContext close（6テスト）
- `audio-file-engine.test.js` 新規追加（5テスト）
  - `pauseAudioFile`/`resumeAudioFile`: audioFileMode条件分岐含む
- `visualizer.test.js` 統合テスト追加（5テスト）
  - `updateChannelGains`: ミュート/ソロ/混合/gainNode不在の動作検証
- `setup-dom.js`: `position-display` 要素追加
- テスト戦略ドキュメント: **全関数のカバレッジマップ完了**（⬜残り0）
  - 7関数を✅完了に、3関数（playNotes/playNotesFrom/playAudioFile）をE2Eカバー注記に更新
- テスト合計: **203テスト**（ユニット139 + 統合64）

## Why
テスト戦略Phase C（Tier 2統合テスト）の完了。全export関数のテストカバレッジマップを埋め終えた。

## Risk
- none