### PR TITLE
ci: add timeout-minutes to all CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   lint:
     name: Lint (Biome)
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -22,6 +23,7 @@ jobs:
   unit:
     name: Unit & Integration (Vitest)
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -40,6 +42,7 @@ jobs:
   e2e:
     name: E2E (Playwright)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -59,6 +62,7 @@ jobs:
   build:
     name: Build (Vite)
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## What
- 全CIジョブに `timeout-minutes` を設定
  - Lint / Unit / Build: 5分
  - E2E (Playwright): 10分（ブラウザインストール含むため余裕を持たせ）

## Why
E2Eジョブがハングして10分以上経過する事象が発生。デフォルトの6時間タイムアウトでは無料枠を無駄に消費するリスクがある。

## Risk
- none