### PR TITLE
ci: run CI on pull_request only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## What
- `ci.yml` の `push: [main]` トリガーを削除し、`pull_request` のみに変更

## Why
PRで全チェック通過後にmainマージで同じテストが二重実行されていた。Actions分の節約とマージ後の待ち時間削減のため。デプロイは `deploy.yml` で別途 `push: main` で走るため影響なし。

## Risk
- low — ブランチ保護でPR必須チェックを設定すれば品質ゲートは維持される